### PR TITLE
Revert increase limit

### DIFF
--- a/anki/decks.py
+++ b/anki/decks.py
@@ -25,6 +25,8 @@ defaultDeck = {
     # added in beta11
     'extendNew': 10,
     'extendRev': 50,
+    'todayExtendNew' : [0, 0],
+    'todayExtendRev' : [0, 0]
 }
 
 defaultDynamicDeck = {

--- a/anki/sched.py
+++ b/anki/sched.py
@@ -1144,6 +1144,11 @@ did = ?, queue = %s, due = ?, mod = ?, usn = ? where id = ?""" % queue, data)
                 g['todayExtendNew'] = [0, 0]
                 g['todayExtendRev'] = [0, 0]
             ##
+            # reset the new/review limit extension
+            if g['todayExtendNew'][0] != self.today:
+                g['todayExtendNew'] = [self.today, 0]
+            if g['todayExtendRev'][0] != self.today:
+                g['todayExtendRev'] = [self.today, 0]
             for t in "new", "rev", "lrn", "time":
                 key = t+"Today"
                 if g[key][0] != self.today:

--- a/anki/sched.py
+++ b/anki/sched.py
@@ -1139,6 +1139,11 @@ did = ?, queue = %s, due = ?, mod = ?, usn = ? where id = ?""" % queue, data)
         # update all daily counts, but don't save decks to prevent needless
         # conflicts. we'll save on card answer instead
         def update(g):
+            ## should be placed in storage.py
+            if 'todayExtendNew' not in g:
+                g['todayExtendNew'] = [0, 0]
+                g['todayExtendRev'] = [0, 0]
+            ##
             for t in "new", "rev", "lrn", "time":
                 key = t+"Today"
                 if g[key][0] != self.today:

--- a/aqt/customstudy.py
+++ b/aqt/customstudy.py
@@ -53,7 +53,6 @@ class CustomStudy(QDialog):
             return "<b>"+str(num)+"</b>"
         if idx == RADIO_NEW:
             new = self.mw.col.sched.totalNewForCurrentDeck()
-            self.deck['newToday']
             tit = _("New cards in deck: %s") % plus(new)
             pre = _("Increase today's new card limit by")
             sval = min(new, self.deck.get('extendNew', 10))

--- a/aqt/customstudy.py
+++ b/aqt/customstudy.py
@@ -23,6 +23,7 @@ class CustomStudy(QDialog):
         QDialog.__init__(self, mw)
         self.mw = mw
         self.deck = self.mw.col.decks.current()
+        self.conf = self.mw.col.decks.getConf(self.deck['conf'])
         self.form = f = aqt.forms.customstudy.Ui_Dialog()
         f.setupUi(self)
         self.setWindowModality(Qt.WindowModal)
@@ -53,15 +54,22 @@ class CustomStudy(QDialog):
             return "<b>"+str(num)+"</b>"
         if idx == RADIO_NEW:
             new = self.mw.col.sched.totalNewForCurrentDeck()
-            tit = _("New cards in deck: %s") % plus(new)
+            # get the number of new cards in deck that exceed the new cards limit
+            newUnderLearning = min(new, self.conf['new']['perDay'] - self.deck['newToday'][1])
+            newExceeding = min(new, new - newUnderLearning)
+            tit = _("New cards in deck over today limit: %s") % plus(newExceeding)
             pre = _("Increase today's new card limit by")
             sval = min(new, self.deck.get('extendNew', 10))
-            smax = new
+            smax = newExceeding
         elif idx == RADIO_REV:
             rev = self.mw.col.sched.totalRevForCurrentDeck()
-            tit = _("Reviews due in deck: %s") % plus(rev)
+            # get the number of review due in deck that exceed the review due limit
+            revUnderLearning = min(rev, self.conf['rev']['perDay'] - self.deck['revToday'][1])
+            revExceeding = min(rev, rev - revUnderLearning)
+            tit = _("Reviews due in deck over today limit: %s") % plus(revExceeding)
             pre = _("Increase today's review limit by")
             sval = min(rev, self.deck.get('extendRev', 10))
+            smax = revExceeding
         elif idx == RADIO_FORGOT:
             pre = _("Review cards forgotten in last")
             post = _("days")

--- a/designer/customstudy.ui
+++ b/designer/customstudy.ui
@@ -16,24 +16,24 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="3" column="0">
-      <widget class="QRadioButton" name="radio4">
-       <property name="text">
-        <string>Review ahead</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QRadioButton" name="radio3">
-       <property name="text">
-        <string>Review forgotten cards</string>
-       </property>
-      </widget>
-     </item>
      <item row="0" column="0">
       <widget class="QRadioButton" name="radio1">
        <property name="text">
         <string>Increase today's new card limit</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QToolButton" name="tbResetExtendNew">
+       <property name="toolTip">
+        <string>Reset new card limit to default</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="icons.qrc">
+         <normaloff>:/icons/edit-undo.png</normaloff>:/icons/edit-undo.png</iconset>
        </property>
       </widget>
      </item>
@@ -44,10 +44,31 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="0">
-      <widget class="QRadioButton" name="radio6">
+     <item row="1" column="1">
+      <widget class="QToolButton" name="tbResetExtendRev">
+       <property name="toolTip">
+        <string>Reset review limit to default</string>
+       </property>
        <property name="text">
-        <string>Study by card state or tag</string>
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="icons.qrc">
+         <normaloff>:/icons/edit-undo.png</normaloff>:/icons/edit-undo.png</iconset>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QRadioButton" name="radio3">
+       <property name="text">
+        <string>Review forgotten cards</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QRadioButton" name="radio4">
+       <property name="text">
+        <string>Review ahead</string>
        </property>
       </widget>
      </item>
@@ -55,6 +76,13 @@
       <widget class="QRadioButton" name="radio5">
        <property name="text">
         <string>Preview new cards</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <widget class="QRadioButton" name="radio6">
+       <property name="text">
+        <string>Study by card state or tag</string>
        </property>
       </widget>
      </item>
@@ -166,7 +194,9 @@
   <tabstop>spin</tabstop>
   <tabstop>buttonBox</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="icons.qrc"/>
+ </resources>
  <connections>
   <connection>
    <sender>buttonBox</sender>


### PR DESCRIPTION
With this modification I've added the following improvements:

*Removed a statement that was doing nothing (please check if it's so)
*Improved usability of the increase new/review card daily limit by showing to the user the number of cards that are left in the deck excluding the ones that are currently under review. This number is equal to the maximum number the user can input in the spinbox. The maximum value allowed in the spin box has been updated accordingly. 

Example:
Consider a new deck. There are 100 (new) cards in the decks. The user new card limit is 10. He has learned 5 new cards. 
In the increase new card limit dialog now the number shown is 90 (before was 95).

*Add two buttons to reset the new/review card limit extension
Sometimes happens to me that I extend the new card limit for today, but than I change my mind. At this point I can't proceed reviewing the cards because also the new ones (that I don't want to learn) will be shown.
Another use case is that I extend a lot the review card limit, but then I change my mind and I would like to finish only the cards in 'Learning' state (the red ones) but new green cards will be shown making me loose time.

To work, the improvement of the two buttons needs two extra field in the deck schema. I've added them in a bad place (inside scheduler.py) but I guess they should added in storage.py. Before merging the pull request I ask you to discard that commit (cherry pick the others) and add the proper code to update the deck schema (I'm not sure how to do it).
