### PR TITLE
Avoid calling checkValid on an empty note

### DIFF
--- a/aqt/editor.py
+++ b/aqt/editor.py
@@ -462,6 +462,8 @@ class Editor(object):
                     "editFocusLost", False, self.note, self.currentField):
                     # something updated the note; schedule reload
                     def onUpdate():
+                        if not self.note:
+                            return
                         self.stealFocus = True
                         self.loadNote()
                         self.checkValid()


### PR DESCRIPTION
Fix error message when editFocusLost is called after editor destruction

https://anki.tenderapp.com/discussions/ankidesktop/11175-bug-in-browser-revealed-by-add-on?unresolve=true
To reproduce:
1. Install the attached add-on. (All it does is register a function on the editFocusLost hook, and set the flag to 1 to signify that a field has been updated).
2. Run Anki. Enter the Browse window. Press Enter to display your deck.
3. Select one card.
4. Click inside one of the fields for that card. Now, when you leave that field, the editFocusLost hook will be called.
5. Now, select 2 notes from the browser, with your mouse, without clicking anywhere else before.

You will observe this error message:

Traceback (most recent call last):
File "aqt/progress.pyc", line 69, in handler 
File "aqt/editor.pyc", line 467, in onUpdate 
File "aqt/editor.pyc", line 572, in checkValid AttributeError: 'NoneType' object has no attribute 'fields'