### PR TITLE
Recognize a couple new media formats.

### DIFF
--- a/aqt/editor.py
+++ b/aqt/editor.py
@@ -20,8 +20,8 @@ import aqt
 import anki.js
 from BeautifulSoup import BeautifulSoup
 
-pics = ("jpg", "jpeg", "png", "tif", "tiff", "gif", "svg")
-audio =  ("wav", "mp3", "ogg", "flac", "mp4", "swf", "mov", "mpeg", "mkv", "m4a")
+pics = ("jpg", "jpeg", "png", "tif", "tiff", "gif", "svg", "webp")
+audio =  ("wav", "mp3", "ogg", "flac", "mp4", "swf", "mov", "mpeg", "mkv", "m4a", "3gp", "spx", "oga")
 
 _html = """
 <html><head>%s<style>


### PR DESCRIPTION
Adding 'webp' was necessary for Anki to recognize webp images
(https://developers.google.com/speed/webp/?csw=1) as images rather than
audio.  The addition of the two audio formats I prefer was just incidental,
as it appears Anki assumes audio files if a file is not an image file.