### PR TITLE
RFC: avoid exception on exit

### DIFF
--- a/aqt/preferences.py
+++ b/aqt/preferences.py
@@ -29,6 +29,9 @@ class Preferences(QDialog):
         self.show()
 
     def accept(self):
+        # avoid exception if main window is already closed
+        if not self.mw.col:
+            return
         self.updateCollection()
         self.updateNetwork()
         self.updateBackup()


### PR DESCRIPTION
Closing anki when the preferences dialog is open will cause an exception since
self.mw.col in Preferences is not available anymore.

<pre>
$ anki
loaded the Generic plugin 
Traceback (most recent call last):
  File "/usr/share/anki/aqt/preferences.py", line 45, in reject
    self.accept()
  File "/usr/share/anki/aqt/preferences.py", line 36, in accept
    self.updateCollection()
  File "/usr/share/anki/aqt/preferences.py", line 67, in updateCollection
    qc = d.conf
AttributeError: 'NoneType' object has no attribute 'conf'
</pre>

Although the exception is eventually caught by the Qt runtime, it is still printed out and reported e.g. by the abrt tool.

https://bugzilla.redhat.com/show_bug.cgi?id=1213100

https://retrace.fedoraproject.org/faf/problems/276690/

Avoid the exception by checking self.mw.col again on accept().

Alternatively, the main window could attempt to close the preferences window itself.

