### PR TITLE
integrate test suite with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+  - "2.7"
+install: 
+  - sudo apt-get update
+  - sudo apt-get install python-qt4 mplayer lame libportaudio2
+  - pip install SQLAlchemy
+  - pip install nose
+
+script: nosetests ./tests


### PR DESCRIPTION
This PR adds the config file with necessary steps to get Anki test suite running, but you'll have to manually enable the project in your Travis console to see the results.
See [here](http://docs.travis-ci.com/user/getting-started/) for more details.

Here's a [sample build](https://travis-ci.org/Inoryy/anki/builds/60231896) output. Seems to be running through full suite without issues.