### PR TITLE
Integrate test suite with Travis CI and Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ install:
 script: nosetests ./tests --with-coverage --cover-package=./anki
 
 after_success:
-  coveralls
+  - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,9 @@ install:
   - sudo apt-get install python-qt4 mplayer lame libportaudio2
   - pip install SQLAlchemy
   - pip install nose
+  - pip install coveralls
 
-script: nosetests ./tests
+script: nosetests ./tests --with-coverage --cover-package=./anki
+
+after_success:
+  coveralls


### PR DESCRIPTION
This merge includes the changes by @Inoryy to integrate with Travis-CI. See https://github.com/dae/anki/pull/103 for his pull request.

In addition, the Travis build will run coverage checks on the ./Anki folder. This is useful for proving that any new code has been tested (the coverage percentage should remain the same, or increase).

There is little configuration outside of accepting the merge. Simply create an account for both travis-ci and coveralls.io and they will automatically link to the Anki github.

Example output (click Show all checks) :
https://github.com/RawToast/anki/pull/3

Coming from an enterprise development background, I strongly suggest these changes are implemented. In fact, CI integration is usually one of the first tasks completed on a project.