### PR TITLE
Bad LaTeX commands

### DIFF
--- a/anki/latex.py
+++ b/anki/latex.py
@@ -78,9 +78,12 @@ def _buildImg(col, latex, fname, model):
     latex = latex.encode("utf8")
     # it's only really secure if run in a jail, but these are the most common
     tmplatex = latex.replace("\\includegraphics", "")
-    for bad in ("write18", "\\readline", "\\input", "\\include", "\\catcode",
-                "\\openout", "\\write", "\\loop", "\\def", "\\shipout"):
-        if bad in tmplatex:
+    for bad in ("write18", "\\\\readline", "\\\\input", "\\\\include",
+                "\\\\catcode", "\\\\openout", "\\\\write", "\\\\loop",
+                "\\\\def", "\\\\shipout"):
+        # don't mind if the sequence is only part of a command
+        bad_re = bad + "[^a-zA-Z]"
+        if re.search(bad_re, tmplatex):
             return _("""\
 For security reasons, '%s' is not allowed on cards. You can still use \
 it by placing the command in a different package, and importing that \

--- a/anki/latex.py
+++ b/anki/latex.py
@@ -78,11 +78,11 @@ def _buildImg(col, latex, fname, model):
     latex = latex.encode("utf8")
     # it's only really secure if run in a jail, but these are the most common
     tmplatex = latex.replace("\\includegraphics", "")
-    for bad in ("write18", "\\\\readline", "\\\\input", "\\\\include",
-                "\\\\catcode", "\\\\openout", "\\\\write", "\\\\loop",
-                "\\\\def", "\\\\shipout"):
+    for bad in ("\\write18", "\\readline", "\\input", "\\include",
+                "\\catcode", "\\openout", "\\write", "\\loop",
+                "\\def", "\\shipout"):
         # don't mind if the sequence is only part of a command
-        bad_re = bad + "[^a-zA-Z]"
+        bad_re = "\\" + bad + "[^a-zA-Z]"
         if re.search(bad_re, tmplatex):
             return _("""\
 For security reasons, '%s' is not allowed on cards. You can still use \

--- a/tests/test_latex.py
+++ b/tests/test_latex.py
@@ -53,3 +53,61 @@ def test_latex():
     assert len(os.listdir(d.media.dir())) == 2
     assert stripHTML(f.cards()[0].q()) == "[latex]foo[/latex]"
     assert ".png" in oldcard.q()
+    # turn it on again so other test don't suffer
+    anki.latex.build = True
+
+def test_bad_latex_command_write18():
+    (result, msg) = _test_includes_bad_command("\\write18")
+    assert result, msg
+
+def test_bad_latex_command_readline():
+    (result, msg) = _test_includes_bad_command("\\readline")
+    assert result, msg
+
+def test_bad_latex_command_input():
+    (result, msg) = _test_includes_bad_command("\\input")
+    assert result, msg
+
+def test_bad_latex_command_include():
+    (result, msg) = _test_includes_bad_command("\\include")
+    assert result, msg
+
+def test_bad_latex_command_catcode():
+    (result, msg) = _test_includes_bad_command("\\catcode")
+    assert result, msg
+
+def test_bad_latex_command_openout():
+    (result, msg) = _test_includes_bad_command("\\openout")
+    assert result, msg
+
+def test_bad_latex_command_write():
+    (result, msg) = _test_includes_bad_command("\\write")
+    assert result, msg
+
+def test_bad_latex_command_loop():
+    (result, msg) = _test_includes_bad_command("\\loop")
+    assert result, msg
+
+def test_bad_latex_command_def():
+    (result, msg) = _test_includes_bad_command("\\def")
+    assert result, msg
+
+def test_bad_latex_command_shipout():
+    (result, msg) = _test_includes_bad_command("\\shipout")
+    assert result, msg
+
+def test_good_latex_command_works():
+    # inserting commands beginning with a bad name should not raise an error
+    (result, msg) = _test_includes_bad_command("\\defeq")
+    assert not result, msg
+    # normal commands should not either
+    (result, msg) = _test_includes_bad_command("\\emph")
+    assert not result, msg
+
+def _test_includes_bad_command(bad):
+    d = getEmptyCol()
+    f = d.newNote()
+    f['Front'] = u'[latex]%s[/latex]' % bad;
+    d.addNote(f)
+    q = f.cards()[0].q()
+    return ("'%s' is not allowed on cards" % bad in q, "Card content: %s" % q)


### PR DESCRIPTION
While creating a set of cards purely based on LaTeX I noticed a peculiar behavior: I was try to use a command named `\defeq` from my standard set of command which creates a `:=` symbol in math mode. That triggered the security measure of not using `\def` in cards. I think that's undesirable so I made the necessary changes to fix this and added a series of test cases to cover this functionality.