### PR TITLE
Update Field Searches to match multi-line fields

### DIFF
--- a/anki/find.py
+++ b/anki/find.py
@@ -433,7 +433,7 @@ where mid in %s and flds like ? escape '\\'""" % (
             ord = mods[str(mid)][1]
             strg = flds[ord]
             try:
-                if re.search("(?i)^"+regex+"$", strg):
+                if re.search("(?si)^"+regex+"$", strg):
                     nids.append(id)
             except sre_constants.error:
                 return


### PR DESCRIPTION
Currently, field searches are confirmed by a regex search with the single option of case-insensitive (?i), and with the beginning and ending markers ^ and $. Since multi-line is not enabled, and re.DOTALL (option s) is not enabled, the field search will fail for any field with a new line.

Adding the re.DOTALL flag (option s) will fix this if it's unintended functionality. Another option would be to add the re.MULTILINE flag 