### PR TITLE
change shebang to explicitly name python2

### DIFF
--- a/runanki
+++ b/runanki
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 sys.path.insert(0, "/usr/share/anki")


### PR DESCRIPTION
Anki is not source compatible with python3, therefore change line according to https://www.python.org/dev/peps/pep-0394/:
```
in preparation for an eventual change in the default version of Python, Python 2 only scripts should either be updated to be source compatible with Python 3 or else to use python2 in the shebang line. 
```

This also avoids workarounds like https://projects.archlinux.org/svntogit/community.git/tree/trunk/PKGBUILD?h=packages/anki in the arch linux package.