### PR TITLE
Don't include media files with _ unless they are referenced in model

### DIFF
--- a/anki/exporting.py
+++ b/anki/exporting.py
@@ -203,7 +203,12 @@ class AnkiExporter(Exporter):
             if self.mediaDir:
                 for fname in os.listdir(self.mediaDir):
                     if fname.startswith("_"):
-                        media[fname] = True
+                        # Scan all models in mids for reference to fname
+                        for m in self.src.models.all():
+                            if int(m['id']) in mids:
+                                if self._modelHasMedia(m, fname):
+                                    media[fname] = True
+                                    break
         self.mediaFiles = media.keys()
         self.dst.crt = self.src.crt
         # todo: tags?
@@ -219,6 +224,16 @@ class AnkiExporter(Exporter):
     
     def removeSystemTags(self, tags):
         return self.src.tags.remFromStr("marked leech", tags)
+
+    def _modelHasMedia(self, model, fname):
+        # First check the styling
+        if fname in model["css"]:
+            return True
+        # If no reference to fname then check the templates as well
+        for t in model["tmpls"]:
+            if fname in t["qfmt"] or fname in t["afmt"]:
+                return True
+        return False
 
 # Packaged Anki decks
 ######################################################################


### PR DESCRIPTION
Custom CJK fonts are often very big (> 5MB) and the way the exporting code currently works, *all* of these will be included in *every* deck you export, regardless of whether they are needed or not. Since I have a few of these, in practice every deck that I export from Anki is over the 20MB gmail attachment limit, which is super annoying.

This PR checks each media file that starts with an underscore to check that it really is needed before adding it to the apkg.