### PR TITLE
Don't use default deck when deck override set to invalid deck

### DIFF
--- a/anki/collection.py
+++ b/anki/collection.py
@@ -379,7 +379,11 @@ insert into cards values (?,?,?,?,?,?,0,0,?,0,0,0,0,0,0,0,0,"")""",
         card = anki.cards.Card(self)
         card.nid = note.id
         card.ord = template['ord']
-        card.did = template['did'] or note.model()['did']
+        # Use template did (deck override) if valid, otherwise model did
+        if template['did'] and template['did'] in self.decks.decks:
+            card.did = template['did']
+        else:
+            card.did = note.model()['did']
         # if invalid did, use default instead
         deck = self.decks.get(card.did)
         if deck['dyn']:


### PR DESCRIPTION
When the override deck is not valid, the more intuitive behavior for users is to not override at all. Advanced users that really want to use this feature will immediately open the deck override settings and see that it's referencing an invalid deck. Advanced users and developers have [all](https://groups.google.com/forum/#!searchin/anki-android/%22deck$20override%22) been [stumped by the old behavior](https://github.com/ankidroid/Anki-Android/issues/3127), it's simply not intuitive.