### PR TITLE
The new `template['did'] in self.decks.decks` check is always `False` against my installation/collection

### DIFF
--- a/anki/collection.py
+++ b/anki/collection.py
@@ -380,7 +380,7 @@ insert into cards values (?,?,?,?,?,?,0,0,?,0,0,0,0,0,0,0,0,"")""",
         card.nid = note.id
         card.ord = template['ord']
         # Use template did (deck override) if valid, otherwise model did
-        if template['did'] and template['did'] in self.decks.decks:
+        if template['did'] and unicode(template['did']) in self.decks.decks:
             card.did = template['did']
         else:
             card.did = note.model()['did']


### PR DESCRIPTION
Commit 38b36323da4e658b9b2e517b79d6cfe192219779 (PR #117) broke the "deck override" card template feature for my installation/collection.

In `_newCard()`, the new `template['did'] in self.decks.decks` check always evaluates to `False` for me, I think because `template['did']` seems to always be an integer value whereas the keys of `self.decks.decks` always seem to be unicode values.

@timrae What types do you see for `template['did']` and `self.decks.decks.keys()[0]` when this runs for you? If the `template['did'] in self.decks.decks` check actually works for you, I wonder if something is causing me to see the wrong types.

Let me know if I can provide additional info. Cheers!