### PR TITLE
commit immediately after executing sql

### DIFF
--- a/anki/db.py
+++ b/anki/db.py
@@ -38,9 +38,11 @@ class DB(object):
         if ka:
             # execute("...where id = :id", id=5)
             res = self._db.execute(sql, ka)
+            self.commit()
         else:
             # execute("...where id = ?", 5)
             res = self._db.execute(sql, a)
+            self.commit()
         if self.echo:
             #print a, ka
             print sql, "%0.3fms" % ((time.time() - t)*1000)
@@ -52,6 +54,7 @@ class DB(object):
         self.mod = True
         t = time.time()
         self._db.executemany(sql, l)
+        self.commit()
         if self.echo:
             print sql, "%0.3fms" % ((time.time() - t)*1000)
             if self.echo == "2":
@@ -68,6 +71,7 @@ class DB(object):
         if self.echo:
             print sql
         self._db.executescript(sql)
+        self.commit()
 
     def rollback(self):
         self._db.rollback()


### PR DESCRIPTION
I noticed that anki committed to database only when exiting, which made it difficult to reserve added cards or review info when system or anki crashed. That happened to me sometimes, which was annoying when you found that you had to re-do what you had done before. So I think it's necessary to commit right after executing sql, and I didn't notice any decrease in database performance in this way.