### PR TITLE
next interval >= prev interval + 1

### DIFF
--- a/anki/sched.py
+++ b/anki/sched.py
@@ -927,7 +927,8 @@ select id from cards where did in %s and queue = 2 and due <= ? limit ?)"""
 
     def _updateRevIvl(self, card, ease):
         idealIvl = self._nextRevIvl(card, ease)
-        card.ivl = min(max(self._adjRevIvl(card, idealIvl), card.ivl+1), self._revConf(card)['maxIvl'])
+        card.ivl = min(max(self._adjRevIvl(card, idealIvl), card.ivl+1),
+                       self._revConf(card)['maxIvl'])
 
     def _adjRevIvl(self, card, idealIvl):
         if self._spreadRev:

--- a/anki/sched.py
+++ b/anki/sched.py
@@ -894,7 +894,7 @@ select id from cards where did in %s and queue = 2 and due <= ? limit ?)"""
         elif ease == 4:
             interval = ivl4
         # interval capped?
-        return max(min(interval, conf['maxIvl']), card.ivl+1)
+        return min(max(interval, card.ivl+1), conf['maxIvl'])
 
     def _fuzzedIvl(self, ivl):
         min, max = self._fuzzIvlRange(ivl)

--- a/anki/sched.py
+++ b/anki/sched.py
@@ -894,7 +894,7 @@ select id from cards where did in %s and queue = 2 and due <= ? limit ?)"""
         elif ease == 4:
             interval = ivl4
         # interval capped?
-        return min(interval, conf['maxIvl'])
+        return max(min(interval, conf['maxIvl']), card.ivl+1)
 
     def _fuzzedIvl(self, ivl):
         min, max = self._fuzzIvlRange(ivl)

--- a/anki/sched.py
+++ b/anki/sched.py
@@ -894,7 +894,7 @@ select id from cards where did in %s and queue = 2 and due <= ? limit ?)"""
         elif ease == 4:
             interval = ivl4
         # interval capped?
-        return min(max(interval, card.ivl+1), conf['maxIvl'])
+        return min(interval, conf['maxIvl'])
 
     def _fuzzedIvl(self, ivl):
         min, max = self._fuzzIvlRange(ivl)
@@ -927,7 +927,7 @@ select id from cards where did in %s and queue = 2 and due <= ? limit ?)"""
 
     def _updateRevIvl(self, card, ease):
         idealIvl = self._nextRevIvl(card, ease)
-        card.ivl = self._adjRevIvl(card, idealIvl)
+        card.ivl = min(max(self._adjRevIvl(card, idealIvl), card.ivl+1), self._revConf(card)['maxIvl'])
 
     def _adjRevIvl(self, card, idealIvl):
         if self._spreadRev:


### PR DESCRIPTION
http://ankisrs.net/docs/manual.html#reviews

One final thing to note is that Anki forces a new interval to be at least 1 day longer than it was previously so that you don’t get stuck reviewing with the same interval forever. 

https://anki.tenderapp.com/discussions/ankidesktop/18382-new-interval-does-not-seem-to-be-updated-with-ease-at-130-and-current-interval-at-7-days

In some cases interval does not grow in fact.