### PR TITLE
Fix automatic horizontal scrolling in browser

### DIFF
--- a/aqt/browser.py
+++ b/aqt/browser.py
@@ -189,7 +189,11 @@ class DataModel(QAbstractTableModel):
         tv = self.browser.form.tableView
         if idx:
             tv.selectRow(idx.row())
+            # we save and then restore the horizontal scroll position because
+            # scrollTo() also scrolls horizontally which is confusing
+            h = tv.horizontalScrollBar().value()
             tv.scrollTo(idx, tv.PositionAtCenter)
+            tv.horizontalScrollBar().setValue(h)
             if count < 500:
                 # discard large selections; they're too slow
                 sm.select(items, QItemSelectionModel.SelectCurrent |


### PR DESCRIPTION
There is an annoying behavior in the browser where the grid is horizontally repositioned when scrolling programmatically. If you have enough columns to be able to scroll horizontally, you will notice this when doing almost anything and it's really frustrating.