### PR TITLE
Fix y axis tick rendering

### DIFF
--- a/anki/stats.py
+++ b/anki/stats.py
@@ -864,8 +864,12 @@ $(function () {
         }
     }
     conf.yaxis.minTickSize = 1;
+    // prevent ticks from having decimals (use whole numbers instead)
+    conf.yaxis.tickDecimals = 0;
     conf.yaxis.tickFormatter = function (val, axis) {
-            return val.toFixed(0);
+            // Just in case we get ticks with decimals, render to one decimal position.  If it's
+            // a whole number then render without any decimal (i.e. without the trailing .0).
+            return val === Math.round(val) ? val.toFixed(0) : val.toFixed(1);
     }
     if (conf.series.pie) {
         conf.series.pie.label.formatter = function(label, series){


### PR DESCRIPTION
Previously, y axis ticks could be fractional.  Fractional ticks were always rounded to the nearest whole number for display.  This leads to confusing graphs where the bar and ticks do not match up.  For example, if the bar is 3 and the tick is 2.5, then the bar renders just above the tick but the tick is rendered as 3. They both then appear to have value 3 but don't line up.

To fix this behavior, we now indicate to flot that for the y axis we don't want fractional tick values (by setting tickDecimals to 0).  flot will pick tick values to accommodate this setting.  If for some reason the ticks are fractional, which shouldn't happen, we will render to one decimal place.  Otherwise we render whole numbers without the decimal.  Since we are counting reviews, this behavior makes more sense, because reviews are always whole numbers and never fractional.