### PR TITLE
change new card queuing order to random instead of due for new cards

### DIFF
--- a/anki/sched.py
+++ b/anki/sched.py
@@ -361,7 +361,7 @@ did = ? and queue = 0 limit ?)""", did, lim)
             if lim:
                 # fill the queue with the current did
                 self._newQueue = self.col.db.list("""
-select id from cards where did = ? and queue = 0 order by due limit ?""", did, lim)
+select id from cards where did = ? and queue = 0 order by random() limit ?""", did, lim)
                 if self._newQueue:
                     self._newQueue.reverse()
                     return True


### PR DESCRIPTION
trying to make it possible to select a random new card instead of the next due one. Thoughts?