### PR TITLE
Add missing boundary at end of multipart/form-data request body generated in Syncer.req()

### DIFF
--- a/anki/sync.py
+++ b/anki/sync.py
@@ -582,7 +582,7 @@ Content-Type: application/octet-stream\r\n\r\n""")
                         tgt.close()
                     break
                 tgt.write(data)
-            buf.write(b'\r\n' + bdry + b'--\r\n')
+        buf.write(b'\r\n' + bdry + b'--\r\n')
         size = buf.tell()
         # connection headers
         headers = {


### PR DESCRIPTION
This makes the sync request sent to the /download endpoint valid multipart/form-data according to [RFC 2046, 5.1](https://tools.ietf.org/html/rfc2046#section-5.1): 

"In the case of multipart entities, ... .  The body must then contain one or more body parts, each preceded by a boundary delimiter line, and the last one followed by a closing boundary delimiter line."