### PR TITLE
Expose cid to anki.template.render

### DIFF
--- a/anki/collection.py
+++ b/anki/collection.py
@@ -511,6 +511,7 @@ where c.nid = n.id and c.id in %s group by nid""" % ids2str(cids)):
         else:
             template = model['tmpls'][0]
         fields['Card'] = template['name']
+        fields['CardId'] = data[0]
         fields['c%d' % (data[4]+1)] = "1"
         # render q & a
         d = dict(id=data[0])


### PR DESCRIPTION
The `anki.template.renderer()` only recevies the information `format` and `fields`. Neither of those contain any reference to the model, note or card.

Hooks inside that function, like the `fmod_SomeFieldModExample`, which are called for templates that contain `{{SomeFieldModExample:Expression}}` have therefore no possibility to detect the original card. Any search based on incomplete information is error prone.

The easiest way to fix that is to add a `CardId` to `fields`.

The only disadvantage is that this field might already exist and be overwritten. Inside the anki codebase no code refers to the `CardId` field, so its safe to overwrite it in that case. For add-ons the likelihood of someone using the `CardId` field is very low - if somebody uses it, it probably has this meaning anyway.
