### PR TITLE
Fix the lambda function for changing the mapping of the fields

### DIFF
--- a/aqt/importing.py
+++ b/aqt/importing.py
@@ -225,7 +225,7 @@ you can enter it here. Use \\t to represent tab."""),
             self.grid.addWidget(QLabel(text), num, 1)
             button = QPushButton(_("Change"))
             self.grid.addWidget(button, num, 2)
-            button.clicked.connect(lambda s=self,n=num: s.changeMappingNum(n))
+            button.clicked.connect(lambda _, s=self,n=num: s.changeMappingNum(n))
 
     def changeMappingNum(self, n):
         f = ChangeMap(self.mw, self.importer.model, self.mapping[n]).getField()


### PR DESCRIPTION
The connect signal passes a bool to the given function by default, we need to ignore it, otherwise the bool will be assigned in s=self and the call will fail.