### PR TITLE
Fixes bug where Tools->Check Media doesn’t detect LaTeX tags inside t…

### DIFF
--- a/anki/media.py
+++ b/anki/media.py
@@ -241,6 +241,8 @@ create table meta (dirMod int, lastUsn int); insert into meta values (0, 0);
         mdir = self.dir()
         # gather all media references in NFC form
         allRefs = set()
+        # force re-rendering of QA. In order to detect LaTeX tags also from the templates
+        self.col.renderQA(None, "all")
         for nid, mid, flds in self.col.db.execute("select id, mid, flds from notes"):
             noteRefs = self.filesInStr(mid, flds)
             # check the refs are in NFC


### PR DESCRIPTION
…he templates.

Issue:
When LaTeX tags are used in Cards template, Tools-> Check Media is unable to detect LaTeX expressions and it won't generate any image.

To showcase the issue I created a shared deck here https://ankiweb.net/shared/info/174454307
The deck contains 3 cards: 
1.  one card with no LaTeX 
2. one card with a LaTeX formula embedded in the note
3. one card with the same LaTeX formula but this time the template contains the LaTeX tags. Like such`[latex]{{Front}}[/latex]`

Steps to reproduce:
1. Import deck https://ankiweb.net/shared/info/174454307
2. Go to Tools->Check Media
3. Only card 2. will have an image inside the `collection.media` folder where there should be images for 2. and 3. 

Proposed fix:
The issue seems to lie with `media.filesInStr` as it's only discovering LaTeX tags directly within the note body rather than first interpolating the note body inside the template and then replacing the LaTeX expressions with image html tags.
Since images are correctly generated when previewing a card, we could extract the common logic from `collection.renderQA` method and call it in `media.check` on a per note basis.

The quick fix below just does it for all the notes from the db by calling the `renderQA` method directly. It would be preferable to go with the former approach but I wanted to get some insight regarding the issue first.

thanks!

