### PR TITLE
Fix open addon folder

### DIFF
--- a/aqt/utils.py
+++ b/aqt/utils.py
@@ -347,8 +347,7 @@ def openFolder(path):
     if isWin:
         subprocess.Popen(["explorer", path])
     else:
-        oldlpath = os.environ.get("LD_LIBRARY_PATH")
-        del os.environ["LD_LIBRARY_PATH"]
+        oldlpath = os.environ.pop("LD_LIBRARY_PATH", None)
         QDesktopServices.openUrl(QUrl("file://" + path))
         if oldlpath:
             os.environ["LD_LIBRARY_PATH"] = oldlpath


### PR DESCRIPTION
The open folder operation would break if the environment variable
LD_LIBRARY_PATH was not set