### PR TITLE
Get drag&drop working on Qt5 OS X

### DIFF
--- a/aqt/editor.py
+++ b/aqt/editor.py
@@ -1074,7 +1074,9 @@ class EditorWebView(AnkiWebView):
 
     def dragEnterEvent(self, evt):
         mime = evt.mimeData()
-        if mime.hasHtml() or mime.hasImage() or mime.hasUrls() or mime.hasText():
+        accept = mime.hasHtml() or mime.hasImage() or mime.hasUrls() \
+                or mime.hasText()
+        if accept:
             evt.accept()
         else:
             evt.ignore()

--- a/aqt/editor.py
+++ b/aqt/editor.py
@@ -1089,8 +1089,10 @@ class EditorWebView(AnkiWebView):
             html, internal = self._processMime(mime)
 
         if not html:
+            evt.ignore()
             return
 
+        evt.accept()
         self.editor.doDrop(html, internal)
 
     # returns (html, isInternal)

--- a/aqt/editor.py
+++ b/aqt/editor.py
@@ -1072,6 +1072,13 @@ class EditorWebView(AnkiWebView):
             return
         self.editor.doPaste(html, internal)
 
+    def dragEnterEvent(self, evt):
+        mime = evt.mimeData()
+        if mime.hasHtml() or mime.hasImage() or mime.hasUrls() or mime.hasText():
+            evt.accept()
+        else:
+            evt.ignore()
+
     def dropEvent(self, evt):
         mime = evt.mimeData()
 


### PR DESCRIPTION
Hello,

I'm a long-time Anki OS X user and was just trying out Anki at HEAD.
I found that drag-and-drop wasn't working at all in the Qt 5 UI.

I added some explicit event `accept()`/`ignore()` calls to make this work on OS X.
I am not able to test this on Linux/Windows.

There's a remaining problem that the `ondragover` event doesn't seem to be called within the `QWebEngineView`. I haven't been able to figure out why. (`ondragenter` is also not called.) Theoretically this [should be possible](http://doc.qt.io/qt-5/qtwebengine-features.html#drag-and-drop)..

This is a start, at least—drag-and-drop works for image files and images dragged from a browser, though everything is just pasted into the focused field rather than the field indicated by the drop event.

Thanks for all your hard work!
Jon