### PR TITLE
Editor buttons hook

### DIFF
--- a/aqt/editor.py
+++ b/aqt/editor.py
@@ -458,6 +458,7 @@ class Editor(object):
 <button tabindex=-1 class=linkb type="button" onclick="pycmd('more');return false;"><img class=topbut src="qrc:/icons/more.png"></button>
 </div>
         """ % dict(flds=_("Fields"), cards=_("Cards"))
+        topbuts = runFilter("setupEditorButtons", topbuts)
         self.web.stdHtml(_html % (
             self.mw.baseHTML(), anki.js.jquery,
             topbuts,

--- a/aqt/editor.py
+++ b/aqt/editor.py
@@ -439,11 +439,11 @@ class Editor(object):
         self.web.onLoadFinished = self._loadFinished
 
         topbuts = """
-<div style="float:left;">
+<div id="topbutsleft" style="float:left;">
 <button onclick="pycmd('fields')">%(flds)s...</button>
 <button onclick="pycmd('cards')">%(cards)s...</button>
 </div>
-<div style="float:right;">
+<div id="topbutsright" style="float:right;">
 <button tabindex=-1 class=linkb type="button" id=bold onclick="pycmd('bold');return false;"><img class=topbut src="qrc:/icons/text_bold.png"></button>
 <button tabindex=-1 class=linkb type="button" id=italic  onclick="pycmd('italic');return false;"><img class=topbut src="qrc:/icons/text_italic.png"></button>
 <button tabindex=-1 class=linkb type="button" id=underline  onclick="pycmd('underline');return false;"><img class=topbut src="qrc:/icons/text_under.png"></button>


### PR DESCRIPTION
Add a filter to process topbuts html in order to allow addons to add new buttons easily.

Maybe it's worth adding a function addButton that does the operation as in the example below? Currently the old _addButton method is unused, maybe we can replace it with one that add the button in the new HTML way.

Example code to add a button:
```
def onSetupEditorButtons(topbuts):
    """Add an a button to the editor
    """
    soup = BeautifulSoup(topbuts, 'html.parser')
    topbutsr = soup.find('div', id='topbutsright')
    ffbtn = soup.new_tag('button', tabindex=-1, type="button", onclick="pycmd('ffvoc');return false;", **{'class': 'linkb'})
    imgpath = os.path.join(iconsDir, 'dictionary.png')
    ffbtnimg = soup.new_tag('img', src=imgpath, **{'class': 'topbut'})
    ffbtn.append(ffbtnimg)
    topbutsr.append(ffbtn)
    return soup.prettify()
```