### PR TITLE
Show latest data under History in the Add dialog

### DIFF
--- a/aqt/addcards.py
+++ b/aqt/addcards.py
@@ -135,14 +135,15 @@ class AddCards(QDialog):
         self.mw.col._remNotes([note.id])
 
     def addHistory(self, note):
-        txt = stripHTMLMedia(",".join(note.fields))[:30]
-        self.history.insert(0, (note.id, txt))
+        self.history.insert(0, note.id)
         self.history = self.history[:15]
         self.historyButton.setEnabled(True)
 
     def onHistory(self):
         m = QMenu(self)
-        for nid, txt in self.history:
+        for nid in self.history:
+            fields = self.mw.col.getNote(nid).fields
+            txt = stripHTMLMedia(",".join(fields))[:30]
             a = m.addAction(_("Edit %s") % txt)
             a.triggered.connect(lambda b, nid=nid: self.editHistory(nid))
         runHook("AddCards.onHistory", self, m)


### PR DESCRIPTION
This is my fix to a bug I discovered:

1. Add a card using the normal interface
2. Edit it by selecting it from History
3. Close the browser after editing
4. Click the History dropdown

Expected result: the fields shown in the dropdown are updated with the changes just made
Actual result: the dropdown shows the original fields before making changes in the browser

By fetching the values from the notes when the dropdown box is clicked, the latest values are always shown.