### PR TITLE
Update required version for Python & PyQt in README.development

### DIFF
--- a/README.development
+++ b/README.development
@@ -12,9 +12,9 @@ provide support for problems you encounter when running from source.
 
 Anki requires:
 
- - Python 3.4+
+ - Python 3.5+
  - Qt 5.5+
- - PyQt5.6+
+ - PyQt5.7.1+
  - mplayer
  - lame
 


### PR DESCRIPTION
Thought it would be of help to others, to update the required version of Python and PyQt in the development readme.

Had quite the fight running Anki with Python 3.4, until I discovered that by default HTTPStatus is only supported by Python 3.5+, according to the Python documentation, that is. 

As I've never coded in Python before, I might be wrong, please excuse me.