### PR TITLE
Update required version for Qt to match PyQt

### DIFF
--- a/README.development
+++ b/README.development
@@ -13,7 +13,7 @@ provide support for problems you encounter when running from source.
 Anki requires:
 
  - Python 3.5+
- - Qt 5.5+
+ - Qt 5.7.1+
  - PyQt5.7.1+
  - mplayer
  - lame


### PR DESCRIPTION
I should have seen this one coming, but didn't. 

It turns out that if PyQt is compiled with a lower Qt version than itself, it inherits the Qt version. In my instance, the laptop was already running an unstable build of Gentoo, hence PyQt5.7.1 pulled in the same version of Qt and everything was fine and dandy.

The workstation on the other hand, is running on a mixed build of stable/unstable, which resulted in PyQt5.7.1 pulling in Qt5.6.2 (lowest Qt5 version possible for PyQt5.7.1). This in turn made PyQt report 5.6.2 as its version, which caused the exception to trigger in Anki.
Updating Qt to 5.7.1 and recompiling PyQt resolved this issue, hence the required version of Qt should be the same as PyQt.