### PR TITLE
Turn "vacuum analyze" into two commands (fix for sqlite 3.15)

### DIFF
--- a/anki/media.py
+++ b/anki/media.py
@@ -446,7 +446,8 @@ create table meta (dirMod int, lastUsn int); insert into meta values (0, 0);
         self.db.execute("update meta set lastUsn=0,dirMod=0")
         self.db.commit()
         self.db.setAutocommit(True)
-        self.db.execute("vacuum analyze")
+        self.db.execute("vacuum")
+        self.db.execute("analyze")
         self.db.setAutocommit(False)
 
     # Media syncing: zips


### PR DESCRIPTION
Before sqlite 3.15, the parameter to vacuum was ignored. Since sqlite 3.15, it became a database name parameter. The "vacuum analyze" syntax was never supported by sqlite, seems to be just a psql thing.

The error for this is "OperationalError: unknown database analyze", and happens when doing a media sync.

------

This should be backported to the stable branch