### PR TITLE
Added setup.py to respository.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 aqt/forms
 locale
 .idea
+build/**
+anki.egg-info/**
+dist/**

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,17 @@
+import os, sys
+from setuptools import setup
+
+setup(
+    name="anki",
+    version="2.1.0a8", # Taken from __init__.py
+    author="Damien Elmes",
+    description=("Anki for desktop computers"),
+    install_requires=[
+        "beautifulsoup4",
+        "send2trash",
+        "httplib2",
+        "pyaudio",
+        "requests"
+    ],
+    packages=["anki"]
+)


### PR DESCRIPTION
Referring to anki as a dependency would be useful for writing libraries that plug into Anki and thus can generate decks. Namely, my project, [proto](https://github.com/cfoust/proto) offers a layer of abstraction that makes it easy to generate Anki decks programmatically. It's been usable for quite awhile, but being able to grab the newest Anki library would be helpful.

This is a simple change that won't take much to upkeep, but is generally good for the whole Anki ecosystem.