### PR TITLE
Minor typographic changes in history browser

### DIFF
--- a/aqt/addcards.py
+++ b/aqt/addcards.py
@@ -144,10 +144,10 @@ class AddCards(QDialog):
         for nid in self.history:
             if self.mw.col.findNotes("nid:%s" % nid):
                 fields = self.mw.col.getNote(nid).fields
-                txt = stripHTMLMedia(",".join(fields))
+                txt = stripHTMLMedia(", ".join(fields))
                 if len(txt) > 30:
                     txt = txt[:30] + "..."
-                a = m.addAction(_("Edit %s") % txt)
+                a = m.addAction(_("Edit \"%s\"") % txt)
                 a.triggered.connect(lambda b, nid=nid: self.editHistory(nid))
             else:
                 a = m.addAction(_("(Note deleted)"))

--- a/aqt/addcards.py
+++ b/aqt/addcards.py
@@ -144,7 +144,9 @@ class AddCards(QDialog):
         for nid in self.history:
             if self.mw.col.findNotes("nid:%s" % nid):
                 fields = self.mw.col.getNote(nid).fields
-                txt = stripHTMLMedia(",".join(fields))[:30]
+                txt = stripHTMLMedia(",".join(fields))
+                if len(txt) > 30:
+                    txt = txt[:30] + "..."
                 a = m.addAction(_("Edit %s") % txt)
                 a.triggered.connect(lambda b, nid=nid: self.editHistory(nid))
             else:


### PR DESCRIPTION
Minor typographic changes to

- Ellipsis for shortened strings
- Quotation marks around card content

The change of the string will need updated translations.

Build is failing at findCards, but it is unrelated to these changes.

Screenshot: 
![image](https://cloud.githubusercontent.com/assets/87876/22624768/f69135ca-eb85-11e6-8e22-0b22441551f7.png)
