### PR TITLE
Stop inheriting from `object`

### DIFF
--- a/anki/cards.py
+++ b/anki/cards.py
@@ -19,7 +19,7 @@ from anki.consts import *
 # - rev queue: integer day
 # - lrn queue: integer timestamp
 
-class Card(object):
+class Card:
 
     def __init__(self, col, id=None):
         self.col = col

--- a/anki/collection.py
+++ b/anki/collection.py
@@ -49,7 +49,7 @@ defaultConf = {
 }
 
 # this is initialized by storage.Collection
-class _Collection(object):
+class _Collection:
 
     def __init__(self, db, server=False, log=False):
         self._debugLog = log

--- a/anki/db.py
+++ b/anki/db.py
@@ -9,7 +9,7 @@ from sqlite3 import dbapi2 as sqlite
 
 Error = sqlite.Error
 
-class DB(object):
+class DB:
     def __init__(self, path, timeout=0):
         self._db = sqlite.connect(path, timeout=timeout)
         self._path = path

--- a/anki/decks.py
+++ b/anki/decks.py
@@ -82,7 +82,7 @@ defaultConf = {
     'usn': 0,
 }
 
-class DeckManager(object):
+class DeckManager:
 
     # Registry save/load
     #############################################################

--- a/anki/exporting.py
+++ b/anki/exporting.py
@@ -8,7 +8,7 @@ from anki.utils import  ids2str, splitFields, json
 from anki.hooks import runHook
 from anki import Collection
 
-class Exporter(object):
+class Exporter:
     def __init__(self, col, did=None):
         self.col = col
         self.did = did

--- a/anki/find.py
+++ b/anki/find.py
@@ -13,7 +13,7 @@ from anki.hooks import *
 # Find
 ##########################################################################
 
-class Finder(object):
+class Finder:
 
     def __init__(self, col):
         self.col = col

--- a/anki/importing/base.py
+++ b/anki/importing/base.py
@@ -7,7 +7,7 @@ from anki.utils import  maxID
 # Base importer
 ##########################################################################
 
-class Importer(object):
+class Importer:
 
     needMapper = False
     needDelimiter = False

--- a/anki/importing/noteimp.py
+++ b/anki/importing/noteimp.py
@@ -13,7 +13,7 @@ from anki.lang import ngettext
 # Stores a list of fields, tags and deck
 ######################################################################
 
-class ForeignNote(object):
+class ForeignNote:
     "An temporary object storing fields and attributes."
     def __init__(self):
         self.fields = []
@@ -21,7 +21,7 @@ class ForeignNote(object):
         self.deck = None
         self.cards = {} # map of ord -> card
 
-class ForeignCard(object):
+class ForeignCard:
     def __init__(self):
         self.due = 0
         self.ivl = 1

--- a/anki/media.py
+++ b/anki/media.py
@@ -15,7 +15,7 @@ from anki.db import DB
 from anki.consts import *
 from anki.latex import mungeQA
 
-class MediaManager(object):
+class MediaManager:
 
     soundRegexps = ["(?i)(\[sound:(?P<fname>[^]]+)\])"]
     imgRegexps = [

--- a/anki/models.py
+++ b/anki/models.py
@@ -69,7 +69,7 @@ defaultTemplate = {
     #'bsize': 12,
 }
 
-class ModelManager(object):
+class ModelManager:
 
     # Saving/loading registry
     #############################################################

--- a/anki/notes.py
+++ b/anki/notes.py
@@ -5,7 +5,7 @@
 from anki.utils import fieldChecksum, intTime, \
     joinFields, splitFields, stripHTMLMedia, timestampID, guid64
 
-class Note(object):
+class Note:
 
     def __init__(self, col, model=None, id=None):
         assert not (model and id)

--- a/anki/sched.py
+++ b/anki/sched.py
@@ -18,7 +18,7 @@ from anki.hooks import runHook
 # revlog types: 0=lrn, 1=rev, 2=relrn, 3=cram
 # positive revlog intervals are in days (rev), negative in seconds (lrn)
 
-class Scheduler(object):
+class Scheduler:
     name = "std"
     haveCustomStudy = True
     _spreadRev = True

--- a/anki/sound.py
+++ b/anki/sound.py
@@ -224,7 +224,7 @@ PYAU_FORMAT = pyaudio.paInt16
 PYAU_CHANNELS = 1
 PYAU_INPUT_INDEX = None
 
-class _Recorder(object):
+class _Recorder:
 
     def postprocess(self, encode=True):
         self.encode = encode

--- a/anki/stats.py
+++ b/anki/stats.py
@@ -14,7 +14,7 @@ from anki.lang import _, ngettext
 # Card stats
 ##########################################################################
 
-class CardStats(object):
+class CardStats:
 
     def __init__(self, col, card):
         self.col = col
@@ -98,7 +98,7 @@ colTime = "#770"
 colUnseen = "#000"
 colSusp = "#ff0"
 
-class CollectionStats(object):
+class CollectionStats:
 
     def __init__(self, col):
         self.col = col

--- a/anki/sync.py
+++ b/anki/sync.py
@@ -22,7 +22,7 @@ HTTP_BUF_SIZE = 64*1024
 # Incremental syncing
 ##########################################################################
 
-class Syncer(object):
+class Syncer:
 
     def __init__(self, col, server=None):
         self.col = col
@@ -457,7 +457,7 @@ class LocalServer(Syncer):
 # Wrapper for requests that tracks upload/download progress
 ##########################################################################
 
-class AnkiRequestsClient(object):
+class AnkiRequestsClient:
 
     def __init__(self):
         self.session = requests.Session()
@@ -496,7 +496,7 @@ class _MonitoringFile(io.BufferedReader):
 # HTTP syncing tools
 ##########################################################################
 
-class HttpSyncer(object):
+class HttpSyncer:
 
     def __init__(self, hkey=None, client=None):
         self.hkey = hkey
@@ -691,7 +691,7 @@ class FullSyncer(HttpSyncer):
 #   assumption other syncers are in sync with the server
 #
 
-class MediaSyncer(object):
+class MediaSyncer:
 
     def __init__(self, col, server=None):
         self.col = col

--- a/anki/tags.py
+++ b/anki/tags.py
@@ -14,7 +14,7 @@ tracked, so unused tags can only be removed from the list with a DB check.
 This module manages the tag cache and tags for notes.
 """
 
-class TagManager(object):
+class TagManager:
 
     # Registry save/load
     #############################################################

--- a/anki/template/template.py
+++ b/anki/template/template.py
@@ -34,7 +34,7 @@ def get_or_attr(obj, name, default=None):
             return default
 
 
-class Template(object):
+class Template:
     # The regular expression used to find a #section
     section_re = None
 

--- a/anki/template/view.py
+++ b/anki/template/view.py
@@ -2,7 +2,7 @@ from anki.template import Template
 import os.path
 import re
 
-class View(object):
+class View:
     # Path where this view's template(s) live
     template_path = '.'
 

--- a/anki/utils.py
+++ b/anki/utils.py
@@ -370,7 +370,7 @@ def platDesc():
 # Debugging
 ##############################################################################
 
-class TimedLog(object):
+class TimedLog:
     def __init__(self):
         self._last = time.time()
     def log(self, s):

--- a/aqt/__init__.py
+++ b/aqt/__init__.py
@@ -41,7 +41,7 @@ from anki.utils import checksum
 # Dialog manager - manages modeless windows
 ##########################################################################emacs
 
-class DialogManager(object):
+class DialogManager:
 
     def __init__(self):
         from aqt import addcards, browser, editcurrent

--- a/aqt/addons.py
+++ b/aqt/addons.py
@@ -17,7 +17,7 @@ from anki.lang import _
 # in the future, it would be nice to save the addon id and unzippped file list
 # to the config so that we can clear up all files and check for updates
 
-class AddonManager(object):
+class AddonManager:
 
     def __init__(self, mw):
         self.mw = mw

--- a/aqt/deckbrowser.py
+++ b/aqt/deckbrowser.py
@@ -12,7 +12,7 @@ import aqt
 from anki.sound import clearAudioQueue
 from anki.hooks import runHook
 
-class DeckBrowser(object):
+class DeckBrowser:
 
     def __init__(self, mw):
         self.mw = mw

--- a/aqt/editor.py
+++ b/aqt/editor.py
@@ -413,7 +413,7 @@ $(function () {
 """
 
 # caller is responsible for resetting note on reset
-class Editor(object):
+class Editor:
     def __init__(self, mw, widget, parentWindow, addMode=False):
         self.mw = mw
         self.widget = widget

--- a/aqt/main.py
+++ b/aqt/main.py
@@ -1037,7 +1037,7 @@ will be lost. Continue?"""))
 
     def _captureOutput(self, on):
         mw = self
-        class Stream(object):
+        class Stream:
             def write(self, data):
                 mw._output += data
         if on:

--- a/aqt/overview.py
+++ b/aqt/overview.py
@@ -7,7 +7,7 @@ from anki.utils import isMac
 import aqt
 from anki.sound import clearAudioQueue
 
-class Overview(object):
+class Overview:
     "Deck overview."
 
     def __init__(self, mw):

--- a/aqt/profiles.py
+++ b/aqt/profiles.py
@@ -60,7 +60,7 @@ profileConf = dict(
     importMode=1,
 )
 
-class ProfileManager(object):
+class ProfileManager:
 
     def __init__(self, base=None, profile=None):
         self.name = None

--- a/aqt/progress.py
+++ b/aqt/progress.py
@@ -12,7 +12,7 @@ from aqt.qt import *
 # Progress info
 ##########################################################################
 
-class ProgressManager(object):
+class ProgressManager:
 
     def __init__(self, mw):
         self.mw = mw

--- a/aqt/reviewer.py
+++ b/aqt/reviewer.py
@@ -19,7 +19,7 @@ from aqt.sound import getAudio
 import aqt
 
 
-class Reviewer(object):
+class Reviewer:
     "Manage reviews.  Maintains a separate state."
 
     def __init__(self, mw):

--- a/aqt/toolbar.py
+++ b/aqt/toolbar.py
@@ -4,7 +4,7 @@
 
 from aqt.qt import *
 
-class Toolbar(object):
+class Toolbar:
 
     def __init__(self, mw, web):
         self.mw = mw


### PR DESCRIPTION
It is not needed in Python 3.