### PR TITLE
Handle invalid delimiters more gracefully

### DIFF
--- a/aqt/importing.py
+++ b/aqt/importing.py
@@ -112,6 +112,11 @@ you can enter it here. Use \\t to represent tab."""),
                 self, help="importing") or "\t"
         str = str.replace("\\t", "\t")
         str = str.encode("ascii")
+        if len(str) > 1:
+            showWarning(_(
+                "Multi-character separators are not supported. "
+                "Please enter one character only."))
+            return
         self.hideMapping()
         def updateDelim():
             self.importer.delimiter = str
@@ -140,7 +145,7 @@ you can enter it here. Use \\t to represent tab."""),
             d = repr(d)
         txt = _("Fields separated by: %s") % d
         self.frm.autoDetect.setText(txt)
-        
+
     def accept(self):
         self.importer.mapping = self.mapping
         if not self.importer.mappingOk():


### PR DESCRIPTION
Hi Damien,
Just ran into this one accidentally. If a user attempts to use anything except a single character as a CSV file delimiter, they get a traceback. I thought you might like them to get a helpful message instead :-)

![error](https://cloud.githubusercontent.com/assets/24988028/22883247/d3ed4042-f236-11e6-91e6-c67d6f91980f.png)
