### PR TITLE
Fix error caused by converting delimiter to bytes

### DIFF
--- a/aqt/importing.py
+++ b/aqt/importing.py
@@ -111,7 +111,6 @@ a tab, comma, and so on. If Anki is detecting the character incorrectly,
 you can enter it here. Use \\t to represent tab."""),
                 self, help="importing") or "\t"
         str = str.replace("\\t", "\t")
-        str = str.encode("ascii")
         if len(str) > 1:
             showWarning(_(
                 "Multi-character separators are not supported. "


### PR DESCRIPTION
Hello again.

I tested that previous patch against an older version of Anki, which meant I didn't notice another problem with `onDelimiter`: Under Python 3, it converts the delimiter to a bytes object, which causes `csv.reader` to choke.

```
Caught exception:
  File "/home/luoliyan/anki/aqt/importing.py", line 124, in onDelimiter
    self.showMapping(hook=updateDelim)
  File "/home/luoliyan/anki/aqt/importing.py", line 205, in showMapping
    hook()
  File "/home/luoliyan/anki/aqt/importing.py", line 123, in updateDelim
    self.importer.updateDelimiter()
  File "/home/luoliyan/anki/anki/importing/csvfile.py", line 113, in updateDelimiter
    reader = csv.reader(self.data, delimiter=self.delimiter, doublequote=True)
<class 'TypeError'>: "delimiter" must be string, not bytes
```

I've tested this fix under Ubuntu 16.10 with the latest Anki.