### PR TITLE
Fix NameError caused by missing import

### DIFF
--- a/aqt/addons.py
+++ b/aqt/addons.py
@@ -7,7 +7,7 @@ from io import StringIO
 import zipfile
 from aqt.qt import *
 from aqt.utils import showInfo, openFolder, isWin, openLink, \
-    askUser, restoreGeom, saveGeom, showWarning
+    askUser, restoreGeom, saveGeom, showWarning, tooltip
 from zipfile import ZipFile
 import aqt.forms
 import aqt


### PR DESCRIPTION
The switch from `showInfo` to `tooltip` in [this commit](https://github.com/dae/anki/commit/f483753b6c6e54b1c20edebf96933fb9dc79c1df) fails because `tooltip` is not imported.
```
...
  File "/home/luoliyan/anki/aqt/addons.py", line 187, in accept
    tooltip(_("Download successful. Please restart Anki."), period=3000)
<class 'NameError'>: name 'tooltip' is not defined
```
(... still getting the hang of GitHub. I guess I need a separate branch for each change, huh?)