### PR TITLE
Remove temporary notes when switching note model

### DIFF
--- a/aqt/addcards.py
+++ b/aqt/addcards.py
@@ -106,6 +106,7 @@ class AddCards(QDialog):
                         note.fields[n] = oldNote.fields[n]
                     except IndexError:
                         pass
+            self.removeTempNote(oldNote)
         self.editor.currentField = 0
         self.editor.setNote(note, focus=True)
 


### PR DESCRIPTION
This is in reference to #122.

Over the past few months I've noticed that I my collection would regularly end up with one or two notes without cards for every 200 notes I added. It looks like this was caused by the fact that `onModelChange` did not delete temporary old notes when switching to a different note type. This commit brings `onModelChange` in line with `onReset` in that it now removes temp notes as well.

It took me a while to figure this out mostly because the issue was very sporadic. I am still not sure why empty notes would only appear so rarely, if at all, but having deployed this change locally for the past few weeks I can confidently say that the bug is fixed.

Edit: It would be great if you could also backport this to the 2.0.x branch as these releases are also affected.