### PR TITLE
Don't register non-existent tags

### DIFF
--- a/anki/tags.py
+++ b/anki/tags.py
@@ -89,7 +89,8 @@ class TagManager:
         if not newTags:
             return
         # cache tag names
-        self.register(newTags)
+        if add:
+            self.register(newTags)
         # find notes missing the tags
         if add:
             l = "tags not "


### PR DESCRIPTION
This is more of a nuisance than a bug, I guess, but I don't think that non-existent tags should be registered just because the user tries to delete them.

To replicate the current behaviour: Click `Remove Tags`, enter `xyz` or some other non-existent tag name, then see it appear in the sidebar.