### PR TITLE
Allow wildcard tag deletion

### DIFF
--- a/anki/tags.py
+++ b/anki/tags.py
@@ -102,7 +102,7 @@ class TagManager:
         res = self.col.db.all(
             "select id, tags from notes where id in %s and (%s)" % (
                 ids2str(ids), lim),
-            **dict([("_%d" % x, '%% %s %%' % y)
+            **dict([("_%d" % x, '%% %s %%' % y.replace('*', '%'))
                     for x, y in enumerate(newTags)]))
         # update tags
         nids = []
@@ -139,13 +139,16 @@ class TagManager:
         return self.join(self.canonify(currentTags))
 
     def remFromStr(self, deltags, tags):
-        "Delete tags if they don't exists."
+        "Delete tags if they exist."
+        def wildcard(pat, str):
+            return '*' in pat and re.search(
+                pat.replace('*', '.*'), str, re.IGNORECASE)
         currentTags = self.split(tags)
         for tag in self.split(deltags):
             # find tags, ignoring case
             remove = []
             for tx in currentTags:
-                if tag.lower() == tx.lower():
+                if (tag.lower() == tx.lower()) or wildcard(tag, tx):
                     remove.append(tx)
             # remove them
             for r in remove:

--- a/anki/tags.py
+++ b/anki/tags.py
@@ -141,8 +141,8 @@ class TagManager:
     def remFromStr(self, deltags, tags):
         "Delete tags if they exist."
         def wildcard(pat, str):
-            return '*' in pat and re.search(
-                pat.replace('*', '.*'), str, re.IGNORECASE)
+            pat = re.escape(pat).replace('\\*', '.*')
+            return '*' in pat and re.search(pat, str, re.IGNORECASE)
         currentTags = self.split(tags)
         for tag in self.split(deltags):
             # find tags, ignoring case

--- a/anki/tags.py
+++ b/anki/tags.py
@@ -142,7 +142,7 @@ class TagManager:
         "Delete tags if they exist."
         def wildcard(pat, str):
             pat = re.escape(pat).replace('\\*', '.*')
-            return '*' in pat and re.search(pat, str, re.IGNORECASE)
+            return re.search(pat, str, re.IGNORECASE)
         currentTags = self.split(tags)
         for tag in self.split(deltags):
             # find tags, ignoring case


### PR DESCRIPTION
I totally understand if this seems like a niche issue, or has too much potential to create problems elsewhere. Feel free to shoot me down on this one - but I would argue that this is the expected behaviour when a user enters `tagName*`, or something similar, in the delete tags box.

To give a bit of context, there are several shared decks that add an enormous number of tags to the collection (imagine `lesson1` to `lesson100` across a thousand cards). The result is a sidebar that is unpleasant to use and impossible to clean up.

This commit also corrects what I assume is an incorrect docstring, because why not :-)