### PR TITLE
Update Python versions for Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
-  - "3.4"
+  - "3.5"
+  - "3.6"
 install: 
   - sudo apt-get update
   - sudo apt-get install portaudio19-dev


### PR DESCRIPTION
I have stopped testing under Python 3.4 due to the PR #152.