### PR TITLE
Preserve tag field focus when switching between cards in the browser

### DIFF
--- a/aqt/browser.py
+++ b/aqt/browser.py
@@ -1518,8 +1518,12 @@ update cards set usn=?, mod=?, did=? where id in """ + scids,
         self.editor.saveNow(self._onPreviousCard)
 
     def _onPreviousCard(self):
+        tagfocus = self.editor.tags.hasFocus()
         f = self.editor.currentField
         self._moveCur(QAbstractItemView.MoveUp)
+        if tagfocus:
+            self.editor.tags.setFocus()
+            return
         self.editor.web.setFocus()
         self.editor.web.eval("focusField(%d)" % f)
 
@@ -1527,8 +1531,12 @@ update cards set usn=?, mod=?, did=? where id in """ + scids,
         self.editor.saveNow(self._onNextCard)
 
     def _onNextCard(self):
+        tagfocus = self.editor.tags.hasFocus()
         f = self.editor.currentField
         self._moveCur(QAbstractItemView.MoveDown)
+        if tagfocus:
+            self.editor.tags.setFocus()
+            return
         self.editor.web.setFocus()
         self.editor.web.eval("focusField(%d)" % f)
 


### PR DESCRIPTION
This is a small improvement to the default behavior when using the the next/previous card shortcut in the browser.

Right now, field focus is only preserved for regular note fields. This commit extends that behaviour to the tags entry, making it easier to move through cards while updating their tags along the way.