### PR TITLE
Improve previewer navigation

### DIFF
--- a/aqt/browser.py
+++ b/aqt/browser.py
@@ -1087,7 +1087,8 @@ where id in %s""" % ids2str(sf))
     def _updatePreviewButtons(self):
         if not self._previewWindow:
             return
-        canBack = self.currentRow() >  0 or self._previewState == "question"
+        current = self.currentRow()
+        canBack = (current > 0 or (current == 0 and self._previewState == "answer" ))
         self._previewPrev.setEnabled(not not (self.singleCard and canBack))
         canForward = self.currentRow() < self.model.rowCount(None) - 1 or \
                      self._previewState == "question"

--- a/aqt/browser.py
+++ b/aqt/browser.py
@@ -1066,8 +1066,8 @@ where id in %s""" % ids2str(sf))
         self.form.previewButton.setChecked(False)
 
     def _onPreviewPrev(self):
-        if self._previewState == "question":
-            self._previewState = "answer"
+        if self._previewState == "answer":
+            self._previewState = "question"
             self._renderPreview()
         else:
             self.onPreviousCard()


### PR DESCRIPTION
This commit addresses a few things in the card previewer which I think might count as inconsistencies.

In particular, the commit changes the following behaviour, as present in the current previewer:

1. When a single card is shown, pressing either the "previous" or "next" button will result in both buttons being disabled
2. When the first card is active and set to the question side, the "previous" button can be pressed despite there being nothing to move back to
3. With the question side active, hitting "previous" will show the answer to that card
4. With the answer side active, hitting "previous" will show the question side of the last card

The updated behaviour in each of these cases looks like this:

1. If on the question side, show "next" button. If on the answer side, show "previous" button
2. Don't show "previous" button on the question side
3. Hitting "previous" while the question side is visible will move the previewer to the question side of the last card
4. Hitting "previous" while the answer side is active will move the previewer back to the question side of that card

I think this behaviour is more in line with what a user might expect when first using the previewer, but there might be a use case I'm not seeing here. If that's the case, please let me know and I'll see if I can come up with something different.