### PR TITLE
'QDialogButtonBox' object has no attribute 'finished'

### DIFF
--- a/aqt/utils.py
+++ b/aqt/utils.py
@@ -74,7 +74,7 @@ def showText(txt, parent=None, type="text", run=True, geomKey=None, \
     def onFinish():
         if geomKey:
             saveGeom(diag, geomKey)
-    box.finished.connect(onFinish)
+    box.accepted.connect(onFinish)
     diag.setMinimumHeight(minHeight)
     diag.setMinimumWidth(minWidth)
     if geomKey:


### PR DESCRIPTION
I get this exception looping because the normal error dialog can't open. I believe this was the original intention.
>  File "..../dae-anki/aqt/utils.py", line 77, in showText
    box.finished.connect(onFinish)
<class 'AttributeError'>: 'QDialogButtonBox' object has no attribute 'finished'