### PR TITLE
Separate sound playback into backends; implement SoX backend

### DIFF
--- a/anki/sound/__init__.py
+++ b/anki/sound/__init__.py
@@ -1,0 +1,184 @@
+# -*- coding: utf-8 -*-
+# Copyright: Damien Elmes <anki@ichi2.net>
+# License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+import re, sys, threading, time, subprocess, os
+import  random
+from anki.hooks import addHook
+from anki.utils import  tmpdir, isWin, isMac, isLin
+
+
+# Shared utils
+##########################################################################
+
+_soundReg = "\[sound:(.*?)\]"
+
+def playFromText(text):
+    for match in re.findall(_soundReg, text):
+        play(match)
+
+def stripSounds(text):
+    return re.sub(_soundReg, "", text)
+
+def hasSound(text):
+    return re.search(_soundReg, text) is not None
+
+# Packaged commands
+##########################################################################
+
+# return modified command array that points to bundled command, and return
+# required environment
+def _packagedCmd(cmd):
+    cmd = cmd[:]
+    env = os.environ.copy()
+    if "LD_LIBRARY_PATH" in env:
+        del env['LD_LIBRARY_PATH']
+    if isMac:
+        dir = os.path.dirname(os.path.abspath(__file__))
+        exeDir = os.path.abspath(dir + "/../../Resources/audio")
+    else:
+        exeDir = os.path.dirname(os.path.abspath(sys.argv[0]))
+        if isWin and not cmd[0].endswith(".exe"):
+            cmd[0] += ".exe"
+    path = os.path.join(exeDir, cmd[0])
+    if not os.path.exists(path):
+        return cmd, env
+    cmd[0] = path
+    return cmd, env
+
+##########################################################################
+
+processingSrc = "rec.wav"
+processingDst = "rec.mp3"
+processingChain = []
+recFiles = []
+
+processingChain = [
+    ["lame", "rec.wav", processingDst, "--noreplaygain", "--quiet"],
+    ]
+
+# don't show box on windows
+if isWin:
+    si = subprocess.STARTUPINFO()
+    try:
+        si.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+    except:
+        # python2.7+
+        si.dwFlags |= subprocess._subprocess.STARTF_USESHOWWINDOW
+else:
+    si = None
+
+def retryWait(proc):
+    # osx throws interrupted system call errors frequently
+    while 1:
+        try:
+            return proc.wait()
+        except OSError:
+            continue
+
+# PyAudio recording
+##########################################################################
+
+import pyaudio
+import wave
+
+PYAU_FORMAT = pyaudio.paInt16
+PYAU_CHANNELS = 1
+PYAU_INPUT_INDEX = None
+
+class _Recorder:
+
+    def postprocess(self, encode=True):
+        self.encode = encode
+        for c in processingChain:
+            #print c
+            if not self.encode and c[0] == 'lame':
+                continue
+            try:
+                cmd, env = _packagedCmd(c)
+                ret = retryWait(subprocess.Popen(cmd, startupinfo=si, env=env))
+            except:
+                ret = True
+            if ret:
+                raise Exception(_(
+                    "Error running %s") %
+                                " ".join(cmd))
+
+class PyAudioThreadedRecorder(threading.Thread):
+
+    def __init__(self):
+        threading.Thread.__init__(self)
+        self.finish = False
+
+    def run(self):
+        chunk = 1024
+        p = pyaudio.PyAudio()
+
+        rate = int(p.get_default_input_device_info()['defaultSampleRate'])
+
+        stream = p.open(format=PYAU_FORMAT,
+                        channels=PYAU_CHANNELS,
+                        rate=rate,
+                        input=True,
+                        input_device_index=PYAU_INPUT_INDEX,
+                        frames_per_buffer=chunk)
+
+        data = b""
+        while not self.finish:
+            try:
+                data += stream.read(chunk)
+            except IOError as e:
+                if e[1] == pyaudio.paInputOverflowed:
+                    pass
+                else:
+                    raise
+        stream.close()
+        p.terminate()
+        wf = wave.open(processingSrc, 'wb')
+        wf.setnchannels(PYAU_CHANNELS)
+        wf.setsampwidth(p.get_sample_size(PYAU_FORMAT))
+        wf.setframerate(rate)
+        wf.writeframes(data)
+        wf.close()
+
+class PyAudioRecorder(_Recorder):
+
+    def __init__(self):
+        for t in recFiles + [processingSrc, processingDst]:
+            try:
+                os.unlink(t)
+            except OSError:
+                pass
+        self.encode = False
+
+    def start(self):
+        self.thread = PyAudioThreadedRecorder()
+        self.thread.start()
+
+    def stop(self):
+        self.thread.finish = True
+        self.thread.join()
+
+    def file(self):
+        if self.encode:
+            tgt = "rec%d.mp3" % time.time()
+            os.rename(processingDst, tgt)
+            return tgt
+        else:
+            return processingSrc
+
+# Audio interface
+##########################################################################
+
+from anki.sound import backends
+
+# FIXME: currently taking the alphabetically first available backend
+_backend = sorted(backends.available.items())[0][1].Backend()
+
+def play(path):
+    _backend.play(path)
+
+def clearAudioQueue():
+    _backend.clearAudioQueue()
+
+Recorder = PyAudioRecorder

--- a/anki/sound/backends/__init__.py
+++ b/anki/sound/backends/__init__.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# Copyright: Damien Elmes <anki@ichi2.net>
+# License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+from abc import ABCMeta, abstractmethod
+
+class Backend(metaclass=ABCMeta):
+    @abstractmethod
+    def play(self, path):
+        pass
+
+    @abstractmethod
+    def clearAudioQueue(self):
+        pass
+
+from pathlib import Path
+import os.path
+import importlib
+
+imported = {}
+
+p = Path(os.path.dirname(__file__))
+for module in [x.name for x in p.iterdir() if x.is_dir()]:
+    if os.path.isfile(str(p) + '/' + module + '/__init__.py'):
+        imported[module] = importlib.import_module('.' + module, __name__)
+del module
+del p
+
+available = {}
+for module in imported:
+    if imported[module].available:
+        available[module] = imported[module]

--- a/anki/sound/backends/mplayer/__init__.py
+++ b/anki/sound/backends/mplayer/__init__.py
@@ -2,78 +2,12 @@
 # Copyright: Damien Elmes <anki@ichi2.net>
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-import re, sys, threading, time, subprocess, os, atexit
-import  random
+import threading, atexit, subprocess
 from anki.hooks import addHook
-from anki.utils import  tmpdir, isWin, isMac, isLin
+from anki.sound import _packagedCmd, si
+from anki.sound.backends import Backend as BaseBackend
+from anki.utils import tmpdir, isWin
 
-# Shared utils
-##########################################################################
-
-_soundReg = "\[sound:(.*?)\]"
-
-def playFromText(text):
-    for match in re.findall(_soundReg, text):
-        play(match)
-
-def stripSounds(text):
-    return re.sub(_soundReg, "", text)
-
-def hasSound(text):
-    return re.search(_soundReg, text) is not None
-
-# Packaged commands
-##########################################################################
-
-# return modified command array that points to bundled command, and return
-# required environment
-def _packagedCmd(cmd):
-    cmd = cmd[:]
-    env = os.environ.copy()
-    if "LD_LIBRARY_PATH" in env:
-        del env['LD_LIBRARY_PATH']
-    if isMac:
-        dir = os.path.dirname(os.path.abspath(__file__))
-        exeDir = os.path.abspath(dir + "/../../Resources/audio")
-    else:
-        exeDir = os.path.dirname(os.path.abspath(sys.argv[0]))
-        if isWin and not cmd[0].endswith(".exe"):
-            cmd[0] += ".exe"
-    path = os.path.join(exeDir, cmd[0])
-    if not os.path.exists(path):
-        return cmd, env
-    cmd[0] = path
-    return cmd, env
-
-##########################################################################
-
-processingSrc = "rec.wav"
-processingDst = "rec.mp3"
-processingChain = []
-recFiles = []
-
-processingChain = [
-    ["lame", "rec.wav", processingDst, "--noreplaygain", "--quiet"],
-    ]
-
-# don't show box on windows
-if isWin:
-    si = subprocess.STARTUPINFO()
-    try:
-        si.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-    except:
-        # python2.7+
-        si.dwFlags |= subprocess._subprocess.STARTF_USESHOWWINDOW
-else:
-    si = None
-
-def retryWait(proc):
-    # osx throws interrupted system call errors frequently
-    while 1:
-        try:
-            return proc.wait()
-        except OSError:
-            continue
 
 # Mplayer settings
 ##########################################################################
@@ -149,7 +83,7 @@ class MplayerMonitor(threading.Thread):
             self.deadPlayers = [pl for pl in self.deadPlayers if clean(pl)]
 
     def kill(self):
-        if not self.mplayer:
+        if not hasattr(self, 'mplayer') or not self.mplayer:
             return
         try:
             self.mplayer.stdin.write(b"quit\n")
@@ -199,6 +133,7 @@ def ensureMplayerThreads():
     if not mplayerManager:
         mplayerManager = MplayerMonitor()
         mplayerManager.daemon = True
+        mplayerManager.startProcess()
         mplayerManager.start()
         # ensure the tmpdir() exit handler is registered first so it runs
         # after the mplayer exit
@@ -213,107 +148,15 @@ def stopMplayer(*args):
 
 addHook("unloadProfile", stopMplayer)
 
-# PyAudio recording
-##########################################################################
+class Backend(BaseBackend):
+    def play(self, path):
+        queueMplayer(path)
 
-import pyaudio
-import wave
+    def clearAudioQueue(self):
+        clearMplayerQueue()
 
-PYAU_FORMAT = pyaudio.paInt16
-PYAU_CHANNELS = 1
-PYAU_INPUT_INDEX = None
-
-class _Recorder:
-
-    def postprocess(self, encode=True):
-        self.encode = encode
-        for c in processingChain:
-            #print c
-            if not self.encode and c[0] == 'lame':
-                continue
-            try:
-                cmd, env = _packagedCmd(c)
-                ret = retryWait(subprocess.Popen(cmd, startupinfo=si, env=env))
-            except:
-                ret = True
-            if ret:
-                raise Exception(_(
-                    "Error running %s") %
-                                " ".join(cmd))
-
-class PyAudioThreadedRecorder(threading.Thread):
-
-    def __init__(self):
-        threading.Thread.__init__(self)
-        self.finish = False
-
-    def run(self):
-        chunk = 1024
-        p = pyaudio.PyAudio()
-
-        rate = int(p.get_default_input_device_info()['defaultSampleRate'])
-
-        stream = p.open(format=PYAU_FORMAT,
-                        channels=PYAU_CHANNELS,
-                        rate=rate,
-                        input=True,
-                        input_device_index=PYAU_INPUT_INDEX,
-                        frames_per_buffer=chunk)
-
-        data = b""
-        while not self.finish:
-            try:
-                data += stream.read(chunk)
-            except IOError as e:
-                if e[1] == pyaudio.paInputOverflowed:
-                    pass
-                else:
-                    raise
-        stream.close()
-        p.terminate()
-        wf = wave.open(processingSrc, 'wb')
-        wf.setnchannels(PYAU_CHANNELS)
-        wf.setsampwidth(p.get_sample_size(PYAU_FORMAT))
-        wf.setframerate(rate)
-        wf.writeframes(data)
-        wf.close()
-
-class PyAudioRecorder(_Recorder):
-
-    def __init__(self):
-        for t in recFiles + [processingSrc, processingDst]:
-            try:
-                os.unlink(t)
-            except OSError:
-                pass
-        self.encode = False
-
-    def start(self):
-        self.thread = PyAudioThreadedRecorder()
-        self.thread.start()
-
-    def stop(self):
-        self.thread.finish = True
-        self.thread.join()
-
-    def file(self):
-        if self.encode:
-            tgt = "rec%d.mp3" % time.time()
-            os.rename(processingDst, tgt)
-            return tgt
-        else:
-            return processingSrc
-
-# Audio interface
-##########################################################################
-
-_player = queueMplayer
-_queueEraser = clearMplayerQueue
-
-def play(path):
-    _player(path)
-
-def clearAudioQueue():
-    _queueEraser()
-
-Recorder = PyAudioRecorder
+try:
+    ensureMplayerThreads()
+    available = True
+except Exception:
+    available = False

--- a/anki/sound/backends/sox/__init__.py
+++ b/anki/sound/backends/sox/__init__.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# Copyright: Damien Elmes <anki@ichi2.net>
+# License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+import subprocess
+from anki.sound.backends import Backend as BaseBackend
+from anki.utils import isLin
+
+def playAvailable():
+    try:
+        play = subprocess.Popen(
+            ['play', '--version'], stdin=subprocess.PIPE,
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        play.wait()
+        return True
+    except OSError:
+        return False
+
+class Backend(BaseBackend):
+    def play(self, path):
+        subprocess.Popen(
+            ['play', path], stdin=subprocess.PIPE,
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+    def clearAudioQueue(self):
+        pass
+
+available = isLin and playAvailable()


### PR DESCRIPTION
Currently this selects the alphabetically first backend to report itself
as available. This should be changed later in favor of user preferences.

Also implements a trivial SoX `play`-based backend.