### PR TITLE
Fix issue where null tag list crashes Mnemosyne import

### DIFF
--- a/anki/importing/mnemo.py
+++ b/anki/importing/mnemo.py
@@ -53,8 +53,12 @@ acq_reps+ret_reps, lapses, card_type_id from cards"""):
                     vocabulary.append(note)
                 elif row[1].startswith("5.1"):
                     cloze[row[0]] = note
+            # check for None to fix issue where import can error out
+            rawTags = row[2];
+            if rawTags is None:
+                rawTags = ""
             # merge tags into note
-            tags = row[2].replace(", ", "\x1f").replace(" ", "_")
+            tags = rawTags.replace(", ", "\x1f").replace(" ", "_")
             tags = tags.replace("\x1f", " ")
             if "tags" not in note:
                 note['tags'] = []


### PR DESCRIPTION
I recently switched over to Anki from Mnemosyne with around 10k cards.  I ran into a crash and debugging revealed the tag list (`rows[2]` in the pull request) was `None` in one of the Mnemosyne cards.

This PR adds a None check to ensure that `.replace` does not crash.

Unfortunately I don't have a Mnemosyne export file example, and I'm not a Python dev so there may be a more elegant way to write this.  However it fixed my issue, I'm happily using Anki, and the change appears to be harmless in the cases it is not trying to fix.

Thanks for Anki!