### PR TITLE
Make hooks.wrap preserve signatures, fixes hooking some pyqt5 callbacks

### DIFF
--- a/anki/hooks.py
+++ b/anki/hooks.py
@@ -13,6 +13,14 @@ If you call wrap() with pos='around', the original function will not be called
 automatically but can be called with _old().
 """
 
+import functools
+
+try:
+    # optional: like functools.wraps, but signature-preserving
+    import decorator
+except ImportError:
+    decorator = None
+
 # Hooks
 ##############################################################################
 
@@ -59,4 +67,11 @@ def wrap(old, new, pos="after"):
             return old(*args, **kwargs)
         else:
             return new(_old=old, *args, **kwargs)
-    return repl
+
+    if decorator is None:
+        return functools.wraps(repl)
+
+    def decorator_wrapper(f, *args, **kwargs):
+        return repl(*args, **kwargs)
+
+    return decorator.decorator(decorator_wrapper)(old)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ send2trash
 httplib2
 pyaudio
 requests
+decorator


### PR DESCRIPTION
It looks like pyqt5 is playing dirty and checking the number of args of
functions before calling them. When using hooks.wrap, pyqt5 thinks it
can pass any amount of arguments (because *args) and you get exceptions
like this inside the wrap function, when calling the 'old' function:

>TypeError: onFindDupes() takes 1 positional argument but 2 were given

This commit fixes it by preserving the signature of the wrapped method,
by adding an optional dependency on the "decorator" module.

Making it an optional dependency is probably not the wisest idea but
since this is a small edge case it might be smoother to start like this.

I also added functools.wraps() as a fallback, which won't help much but
is slightly more correct.

See this article for details: https://hynek.me/articles/decorators/

------

I noticed this while trying to fix [Merge_Duplicates.py](https://ankiweb.net/shared/info/800415564), and there was a similar report [in the forums](https://anki.tenderapp.com/discussions/beta-testing/180-anki-210-alpha-4/page/2#comment_40743280) last year

Some alternatives to this:

* Hard-depend on `decorator`. Safer, particularly if addons end up relying on this.
* Vendor `decorator.py`. Quoting the article:

    >The next easiest way is the single-file decorator.py package. It has no dependencies itself and authors are encouraged to vendor it by just dropping it into their own projects if they want to avoid dependencies too

* Use `boltons` or `wrapt` instead (as proposed by the article). I don't think classmethods were supported by hooks.wraps before, so `decorator` is appropriate. `wrapt` is bigger and `boltons` has unrelated stuff.

* Fix pyqt to use `inspect.signature` or check the `__wrapped__` attribute, so that it works with just `functools.wraps()`. This sounds good but I don't know what part of pyqt is doing this stuff. It would also mean fixing the issue only for python 3.4 or newer.