### PR TITLE
Hide RuntimeError when a window is closed before the DOM is ready

### DIFF
--- a/aqt/webview.py
+++ b/aqt/webview.py
@@ -213,10 +213,16 @@ body { zoom: %f; %s }
 
     def evalWithCallback(self, js, cb):
         if self._domDone:
-            if cb:
-                self.page().runJavaScript(js, cb)
-            else:
-                self.page().runJavaScript(js)
+            # If the AnkiWebView object was deleted (i.e. the window was
+            # closed before the DOM was ready) a RuntimeError is raised -
+            # hide this from the user as it doesn't cause any problems
+            try:
+                if cb:
+                    self.page().runJavaScript(js, cb)
+                else:
+                    self.page().runJavaScript(js)
+            except RuntimeError:
+                pass
         else:
             self._pendingJS.append([js, cb])
 


### PR DESCRIPTION
Fixes the first issue from https://anki.tenderapp.com/discussions/beta-testing/661-anki-210-beta-7#comment_43151523

As far as I'm aware there isn't a way to tell if the object was deleted without catching an error - otherwise I would've checked properly.