### PR TITLE
Add new hook to get info about card that will be undone

### DIFF
--- a/anki/collection.py
+++ b/anki/collection.py
@@ -627,6 +627,14 @@ where c.nid == f.id
         c = data.pop()
         if not data:
             self.clearUndo()
+
+        # get latest revlog entry got card
+        last = self.db.scalar(
+            "select id from revlog where cid = ? "
+            "order by id desc limit 1", c.id)
+
+        runHook("preUndo", c, last)
+
         # remove leech tag if it didn't have it before
         if not wasLeech and c.note().hasTag("leech"):
             c.note().delTag("leech")
@@ -634,9 +642,7 @@ where c.nid == f.id
         # write old data
         c.flush()
         # and delete revlog entry
-        last = self.db.scalar(
-            "select id from revlog where cid = ? "
-            "order by id desc limit 1", c.id)
+        
         self.db.execute("delete from revlog where id = ?", last)
         # restore any siblings
         self.db.execute(


### PR DESCRIPTION
### Reasoning
If you want to make an addon that is stateful based on cards, you need to know the state of a card before an undo occurs for cleanup.

### Current state
Unless you want to make your addon dependent on Anki internals, you can only fetch the card AFTER the undo event occurred (by wrapping undo(self) in collection.py)

### Existing workarounds
1) Copy-paste Anki internals and make your addon dependent on a given Anki version
2) Reimplement undo tracking logic yourself - Complicated and error prone

### Enabled scenario
This new hook lets you access the card that will be deleted and also gives you revlog id for the action. The revlog is useful because you can use it to see the ease the user selected for the card.

### Problems

1. It's kind of awkward that if you wanted to track before/after an undo action, you need to use a hook for the undo and a wrap for the post.
2. I'm not sure if the revlog if something addon authors are supposed to access and therefore maybe we shouldn't add the revlog id to the hook. We could pass the relevant revlog data directly instead.

Other function: https://github.com/dae/anki/blob/1c88315e869beba7d33f053772b6314ca6986a73/aqt/main.py#L672L683