### PR TITLE
Fix decks being moved to the default deck when dragged to the bottom

### DIFF
--- a/web/deckbrowser.js
+++ b/web/deckbrowser.js
@@ -24,7 +24,7 @@ function init() {
 
 function handleDropEvent(event, ui) {
     var draggedDeckId = ui.draggable.attr('id');
-    var ontoDeckId = $(this).attr('id');
+    var ontoDeckId = $(this).attr('id') || '';
 
     pycmd("drag:" + draggedDeckId + "," + ontoDeckId);
 }


### PR DESCRIPTION
Previously ontoDeckId was undefined if a deck was moved to the bottom, resulting in it being moved to the default deck, instead of being made a top-level deck.