### PR TITLE
Pass on Editor instance when running "setupEditorShortcuts" filter

### DIFF
--- a/aqt/editor.py
+++ b/aqt/editor.py
@@ -163,7 +163,7 @@ class Editor:
             ("Ctrl+Shift+X", self.onHtmlEdit),
             ("Ctrl+Shift+T", self.onFocusTags)
         ]
-        runFilter("setupEditorShortcuts", cuts)
+        runFilter("setupEditorShortcuts", cuts, self)
         for keys, fn in cuts:
             QShortcut(QKeySequence(keys), self.widget, activated=fn)
 


### PR DESCRIPTION
Passing on the current Editor instance could provide add-on authors with the ability to freely modify all default key bindings. It would also make it easier to implement instance-specific bindings (e.g. for AddCards or the Browser).

Full disclaimer: I have not been able to test my PRs on a live source code build. Setting up a dev environment for Python3.6/Qt5.9 has turned out to be incredibly difficult on Ubuntu 14.04. Instead I had to opt for testing these changes using smaller add-ons like [this one](https://gist.github.com/glutanimate/13df7e7f15f01c10fba71906f2beb0e5).

Sorry in advance if I made any mistakes while copying the changes over or missed anything else. I tried to be as diligent with this as possible, I understand that it's not the same as actually running Anki from a source build.