### PR TITLE
Convenience function to assign function a button, bridge cmd & shortcut

### DIFF
--- a/aqt/editor.py
+++ b/aqt/editor.py
@@ -125,6 +125,18 @@ class Editor:
             data64 = b''.join(base64.encodestring(data).splitlines())
             return 'data:%s;base64,%s' % (mime, data64.decode('ascii'))
 
+    def addButton(self, icon, cmd, func, tip="", label="", 
+                  id=None, toggleable=False, keys=None):
+        """Assign func to bridge cmd, register shortcut, return button"""
+        if cmd not in self._links:
+            self._links[cmd] = func
+        if keys:
+            s = QShortcut(QKeySequence(keys), self.widget,
+                activated = lambda s=self: func(s))
+        btn = self._addButton(icon, cmd, tip=tip, label=label,
+                              id=id, toggleable=toggleable)
+        return btn
+
     def _addButton(self, icon, cmd, tip="", id=None, toggleable=False):
         if os.path.isabs(icon):
             iconstr = self.resourceToData(icon)

--- a/aqt/editor.py
+++ b/aqt/editor.py
@@ -131,8 +131,8 @@ class Editor:
         if cmd not in self._links:
             self._links[cmd] = func
         if keys:
-            s = QShortcut(QKeySequence(keys), self.widget,
-                activated = lambda s=self: func(s))
+            QShortcut(QKeySequence(keys), self.widget,
+                      activated = lambda s=self: func(s))
         btn = self._addButton(icon, cmd, tip=tip, label=label,
                               id=id, toggleable=toggleable)
         return btn


### PR DESCRIPTION
This is meant to more closely imitate the old _addButton method in Anki 2.0. Its primary purpose is to reduce the boilerplate code needed for add-on authors to implement a new button alongside its hotkey. Hopefully this will help with the transition to Anki 2.1.

For a live test case please see here: https://gist.github.com/glutanimate/13df7e7f15f01c10fba71906f2beb0e5