### PR TITLE
Update required python version to 3.6+

### DIFF
--- a/README.development
+++ b/README.development
@@ -12,7 +12,7 @@ provide support for problems you encounter when running from source.
 
 Anki requires:
 
- - Python 3.5+
+ - Python 3.6+
  - Qt 5.9+ and a PyQT that supports it
  - mplayer
  - lame


### PR DESCRIPTION
It looks like python3.6 is now required. As usual I only figured this out after setting up a python3.5 dev environment...