### PR TITLE
Improve keyboard navigation in TagEdit

### DIFF
--- a/aqt/tagedit.py
+++ b/aqt/tagedit.py
@@ -36,6 +36,16 @@ class TagEdit(QLineEdit):
         self.showCompleter()
 
     def keyPressEvent(self, evt):
+        if (evt.key() == Qt.Key_Tab and evt.modifiers() & Qt.ControlModifier):
+            if not self.completer.popup().isVisible():
+                self.showCompleter()
+            # select next completion
+            index = self.completer.currentIndex()
+            self.completer.popup().setCurrentIndex(index)
+            cur_row = index.row()
+            if not self.completer.setCurrentRow(cur_row + 1):
+                self.completer.setCurrentRow(0)
+            return
         if evt.key() in (Qt.Key_Enter, Qt.Key_Return):
             self.hideCompleter()
             QWidget.keyPressEvent(self, evt)

--- a/aqt/tagedit.py
+++ b/aqt/tagedit.py
@@ -37,9 +37,9 @@ class TagEdit(QLineEdit):
 
     def keyPressEvent(self, evt):
         if (evt.key() == Qt.Key_Tab and evt.modifiers() & Qt.ControlModifier):
+            # select next completion
             if not self.completer.popup().isVisible():
                 self.showCompleter()
-            # select next completion
             index = self.completer.currentIndex()
             self.completer.popup().setCurrentIndex(index)
             cur_row = index.row()
@@ -47,6 +47,12 @@ class TagEdit(QLineEdit):
                 self.completer.setCurrentRow(0)
             return
         if evt.key() in (Qt.Key_Enter, Qt.Key_Return):
+            # apply first completion if no suggestion selected
+            selected_row = self.completer.popup().currentIndex().row()
+            if selected_row == -1:
+                self.completer.setCurrentRow(0)
+                index = self.completer.currentIndex()
+                self.completer.popup().setCurrentIndex(index)
             self.hideCompleter()
             QWidget.keyPressEvent(self, evt)
             return

--- a/aqt/tagedit.py
+++ b/aqt/tagedit.py
@@ -36,6 +36,11 @@ class TagEdit(QLineEdit):
         self.showCompleter()
 
     def keyPressEvent(self, evt):
+        if evt.key() in (Qt.Key_Up, Qt.Key_Down):
+            # show completer on arrow key up/down
+            if not self.completer.popup().isVisible():
+                self.showCompleter()
+            return
         if (evt.key() == Qt.Key_Tab and evt.modifiers() & Qt.ControlModifier):
             # select next completion
             if not self.completer.popup().isVisible():

--- a/aqt/tagedit.py
+++ b/aqt/tagedit.py
@@ -91,12 +91,14 @@ class TagCompleter(QCompleter):
         self.cursor = None
 
     def splitPath(self, tags):
-        tags = tags.strip()
-        tags = re.sub("  +", " ", tags)
-        self.tags = self.edit.col.tags.split(tags)
+        stripped_tags = tags.strip()
+        stripped_tags = re.sub("  +", " ", stripped_tags)
+        self.tags = self.edit.col.tags.split(stripped_tags)
         self.tags.append("")
         p = self.edit.cursorPosition()
-        self.cursor = tags.count(" ", 0, p)
+        self.cursor = stripped_tags.count(" ", 0, p)
+        if tags.endswith(" "):
+            self.cursor += 1
         return [self.tags[self.cursor]]
 
     def pathFromIndex(self, idx):

--- a/aqt/tagedit.py
+++ b/aqt/tagedit.py
@@ -96,9 +96,10 @@ class TagCompleter(QCompleter):
         self.tags = self.edit.col.tags.split(stripped_tags)
         self.tags.append("")
         p = self.edit.cursorPosition()
-        self.cursor = stripped_tags.count(" ", 0, p)
-        if tags.endswith(" "):
-            self.cursor += 1
+        if tags.endswith("  "):
+            self.cursor = len(self.tags) - 1
+        else:
+            self.cursor = stripped_tags.count(" ", 0, p)
         return [self.tags[self.cursor]]
 
     def pathFromIndex(self, idx):
@@ -110,4 +111,4 @@ class TagCompleter(QCompleter):
             self.tags.remove("")
         except ValueError:
             pass
-        return " ".join(self.tags)
+        return " ".join(self.tags) + " "


### PR DESCRIPTION
This pull request includes a number of changes that target the tag entry widget. As a whole, they are meant to improve the tag editing workflow when using the keyboard. Most of these modifications build upon features already found in the [Tag Entry Enhancements](https://ankiweb.net/shared/info/1348430474) add-on which has seen a lot of positive feedback and downloads over the past few months.

Specifically I have performed the following changes:

- With the tag entry widget focused, **Ctrl+Tab** will now allow users to **rotate** through the list of auto-suggestions. If the popup is not visible it will automatically be invoked. Up to this point users had to move their hands away from the home row in order to switch between entries using the arrow keys. With this new key assignment that will no longer be necessary.
- Also in line with this change is the assignment of the **Enter/Return** key to **applying the first available auto-suggestion**. This should allow users to enter their tags lightning-fast, especially when coupled with the next addition:
- Inserted tags are now **automatically separated by spaces**. Users will no longer have to move to the next tag manually, but can rather keep typing their tags fluently.
- Hitting the **space**-bar again will now also update the auto-suggestion popup and provide users with a **selection of all available tags**, just like when focusing the tag entry initially. I think this is much more desirable than the old behaviour where the popup would only show the previous completion until users typed in a character other than space
- Last, for users that are used to the **arrow keys**, this PR also includes a change that allows these keys to **invoke the popup** if it isn't visible, yet.

Taken together, these changes – albeit small – should have a major impact on the usability of the tag entry widget for keyboard-centric users.