### PR TITLE
Setup shortcuts after setting-up web.

### DIFF
--- a/aqt/editor.py
+++ b/aqt/editor.py
@@ -50,8 +50,8 @@ class Editor:
         # current card, for card layout
         self.card = None
         self.setupOuter()
-        self.setupShortcuts()
         self.setupWeb()
+        self.setupShortcuts()
         self.setupTags()
 
     # Initial setup


### PR DESCRIPTION
Swapped setup order. This is to make porting add-ons which use shortcuts for editor buttons easier.
Please see below what I am trying to achieve:

```python
from aqt.utils import showInfo
from anki.hooks import addHook

# cross out the currently selected text
def onStrike(editor):
    editor.web.eval("wrap('<del>', '</del>');")

def addMyButton(buttons, editor):
    editor._links['strike'] = onStrike
    return buttons + [editor._addButton(
        "iconname", # "/full/path/to/icon.png",
        "strike", # link name
        "tooltip")]

def addMyShortcut(shortcuts, editor):
    shortcuts.append(("Ctrl+S", editor._links['strike']))

addHook("setupEditorButtons", addMyButton)
addHook("setupEditorShortcuts", addMyShortcut)
```

This may look tedious - I could just write `addHook("setupEditorShortcuts", onStrike)` in this example - but some add-ons have callbacks buried deeply in the buttons initialization (eariler shortcuts were defined on PyQt buttons, so there was no such a problem before). This would be a really nice addition.

As it is add-on specific need and I understand if you decide to reject this PR.