### PR TITLE
Fix play sound with HTML special symbols in its filename

### DIFF
--- a/anki/sound.py
+++ b/anki/sound.py
@@ -2,6 +2,7 @@
 # Copyright: Damien Elmes <anki@ichi2.net>
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
+import html
 import re, sys, threading, time, subprocess, os, atexit
 import  random
 from anki.hooks import addHook
@@ -14,6 +15,8 @@ _soundReg = "\[sound:(.*?)\]"
 
 def playFromText(text):
     for match in allSounds(text):
+        # filename is html encoded
+        match = html.unescape(match)
         play(match)
 
 def allSounds(text):


### PR DESCRIPTION
This commit fixes a bug when Anki doesn't play an audio file if it has HTML special symbols (like "&") in its filename.

**Reproduction Steps:**
1. Save any mp3 file (for example, http://dict.youdao.com/dictvoice?audio=smoothly&type=1) locally under the name `audio&.mp3`.
2. Insert it in a note (press F3).
3. Save a note.
4. Go to the deck and study it or open this card in Browser.

**Expected result:**
Anki plays sound
**Actual result:**
Anki doesn't play sound

The cause of the bug is that all characters (including `sound` tag content) are HTML encoded on a note. We need to decode HTML special symbols in a filename before playing it.