### PR TITLE
Bind mediaserver on 127.0.0.1 instead of localhost

### DIFF
--- a/aqt/mediasrv.py
+++ b/aqt/mediasrv.py
@@ -48,7 +48,7 @@ class MediaServer(threading.Thread):
     _ready = threading.Event()
 
     def run(self):
-        self.server = ThreadedHTTPServer(("localhost", 0), RequestHandler)
+        self.server = ThreadedHTTPServer(("127.0.0.1", 0), RequestHandler)
         self._ready.set()
         self.server.serve_forever()
 


### PR DESCRIPTION
This fixes a crash on startup that I was experiencing.

See bug report: https://anki.tenderapp.com/discussions/beta-testing/947-cannot-assign-requested-address-error-on-app-startup

And reduced test case on Stack Overflow: https://stackoverflow.com/questions/47966461/httpserver-cannot-assign-requested-address-on-localhost-vs-127-0-0-1