### PR TITLE
Fix string decode error when importing csv files

### DIFF
--- a/anki/importing/csvfile.py
+++ b/anki/importing/csvfile.py
@@ -74,7 +74,7 @@ class TextImporter(NoteImporter):
         self.data = [sub(x)+"\n" for x in self.data.split("\n") if sub(x) != "__comment"]
         if self.data:
             if self.data[0].startswith("tags:"):
-                tags = str(self.data[0][5:], "utf8").strip()
+                tags = str(self.data[0][5:]).strip()
                 self.tagsToAdd = tags.split(" ")
                 del self.data[0]
             self.updateDelimiter()


### PR DESCRIPTION
I tried using the method described [here](https://apps.ankiweb.net/docs/manual.html#adding-tags) to add tags to notes when importing from a plain text file, but got the following error:
```
Import failed. Debugging info:
Traceback (most recent call last):
File "/home/carl/Programming/Python/anki/aqt/importing.py", line 297, in importFile
importer.open()
File "/home/carl/Programming/Python/anki/anki/importing/csvfile.py", line 61, in open
self.cacheFile()
File "/home/carl/Programming/Python/anki/anki/importing/csvfile.py", line 66, in cacheFile
self.openFile()
File "/home/carl/Programming/Python/anki/anki/importing/csvfile.py", line 77, in openFile
tags = str(self.data[0][5:], "utf8").strip()
TypeError: decoding str is not supported
```
Removing the decoding parameter to `str()` fixed this.