### PR TITLE
Factor out definition of context menu in reviewer.py

### DIFF
--- a/aqt/reviewer.py
+++ b/aqt/reviewer.py
@@ -568,7 +568,7 @@ time = %(time)d;
     ##########################################################################
 
     # note the shortcuts listed here also need to be defined above
-    def showContextMenu(self):
+    def _contextMenu(self):
         opts = [
             [_("Flag Card"), [
                 [_("Red Flag"), "Ctrl+1", lambda: self.setFlag(1)],
@@ -590,6 +590,10 @@ time = %(time)d;
             [_("Record Own Voice"), "Shift+V", self.onRecordVoice],
             [_("Replay Own Voice"), "V", self.onReplayRecorded],
         ]
+        return opts
+    
+    def showContextMenu(self):
+        opts = self._contextMenu()
         m = QMenu(self.mw)
         self._addMenuItems(m, opts)
 


### PR DESCRIPTION
Handle definition of context menu in same way that shortcutKeys are handled. This makes it easier for add-ons to modify the context menu without needing to re-implement the whole showContextMenu method.