### PR TITLE
Make it possible to create narrow browser window.

### DIFF
--- a/designer/browser.ui
+++ b/designer/browser.ui
@@ -12,7 +12,7 @@
   </property>
   <property name="minimumSize">
    <size>
-    <width>750</width>
+    <width>400</width>
     <height>400</height>
    </size>
   </property>


### PR DESCRIPTION
I find it convenient to split screen space vertically and place one window on
the left and another on the right. Unfortunately, in my case the current
minimum width of browser window is too wide to do so.

This changeset reduces the minimum width of browser window from 750 to 400.
The actual value of 400 is somewhat arbitrary and copied from main window settings.