### PR TITLE
'bzr clone' deprecated (use 'bzr branch' instead)

### DIFF
--- a/README.development
+++ b/README.development
@@ -42,7 +42,7 @@ translation services. If you want to use a language other than English:
 
 $ cd ..
 $ mv anki dtop # i18n code expects anki folder to be called dtop
-$ bzr clone lp:anki i18n
+$ bzr branch lp:anki i18n
 $ cd i18n
 $ ./update-mos.sh
 $ cd ../dtop


### PR DESCRIPTION
Using bazaar I get this advice :

```
$ bzr clone lp:anki i18n
The command 'bzr clone' has been deprecated in bzr 2.4. Please use 'bzr branch' instead.

$ bzr --version
Bazaar (bzr) 2.8.0dev1
  Python interpreter: /usr/bin/python 2.7.13
  Python standard library: /usr/lib/python2.7
  Platform: Linux-4.9.0-5-amd64-x86_64-with-debian-9.3
  bzrlib: /usr/lib/python2.7/dist-packages/bzrlib
```