### PR TITLE
support middle button paste in addcard-fields in X11 window system.

### DIFF
--- a/aqt/editor.py
+++ b/aqt/editor.py
@@ -693,7 +693,10 @@ to a cloze type first, via Edit>Change Note Type."""))
                                   lambda _: self.doPaste(html, internal))
 
     def onPaste(self):
-        self.web.onPaste()
+        self.web.onPaste(QClipboard.Clipboard)
+
+    def onPasteFromSelection(self):
+        self.web.onPaste(QClipboard.Selection)
 
     def onCutOrCopy(self):
         self.web.flagAnkiText()
@@ -761,6 +764,7 @@ to a cloze type first, via Edit>Change Note Type."""))
         more=onAdvanced,
         dupes=showDupes,
         paste=onPaste,
+        pasteFromSelection=onPasteFromSelection,
         cutOrCopy=onCutOrCopy,
     )
 
@@ -789,9 +793,15 @@ class EditorWebView(AnkiWebView):
     def onCopy(self):
         self.triggerPageAction(QWebEnginePage.Copy)
 
-    def onPaste(self):
+    def onPaste(self, mode):
+        # A better way is to ask user whether mode should be set to
+        # QClipboard.Clipboard, so that windows user can
+        # use middle mouse button to paste as well.
+        clipboard = self.editor.mw.app.clipboard()
+        if (mode == QClipboard.Selection and not clipboard.supportsSelection()):
+            return
         extended = self.editor.mw.app.queryKeyboardModifiers() & Qt.ShiftModifier
-        mime = self.editor.mw.app.clipboard().mimeData(mode=QClipboard.Clipboard)
+        mime = clipboard.mimeData(mode=mode)
         html, internal = self._processMime(mime)
         if not html:
             return

--- a/web/editor.js
+++ b/web/editor.js
@@ -179,6 +179,19 @@ function onPaste(elem) {
     window.event.preventDefault();
 }
 
+function onMouseUp(elem) {
+    // The X11 Window System has the concept of a separate selection and clipboard.
+    // When text is selected, it is immediately available as the global mouse selection.
+    // The global mouse selection may later be copied to the clipboard.
+    // By convention, the middle mouse button is used to paste the global mouse selection.
+    if (event.which == 2) // middle mouse button up; should paste from X11 primary selection.
+    {
+	window.focus();
+	pycmd("pasteFromSelection");
+	window.event.preventDefault();
+    }
+}
+
 function caretToEnd() {
     var r = document.createRange();
     r.selectNodeContents(currentField);
@@ -269,7 +282,7 @@ function setFields(fields) {
             f = "<br>";
         }
         txt += "<tr><td class=fname>{0}</td></tr><tr><td width=100%>".format(n);
-        txt += "<div id=f{0} onkeydown='onKey();' oninput='checkForEmptyField()' onmouseup='onKey();'".format(i);
+        txt += "<div id=f{0} onkeydown='onKey();' oninput='checkForEmptyField()' onmouseup='onMouseUp();'".format(i);
         txt += " onfocus='onFocus(this);' onblur='onBlur();' class=field ";
         txt += "ondragover='onDragOver(this);' onpaste='onPaste(this);' ";
         txt += "oncopy='onCutOrCopy(this);' oncut='onCutOrCopy(this);' ";


### PR DESCRIPTION
## What changes I made
In **adding card** GUI, I add support for using the middle mouse button to paste from [Primary Selection](https://en.wikipedia.org/wiki/X_Window_selection#Clipboard) for X11 users.

## How
add listener to fields, and when middle mouse button up event is triggered, execute ``pycmd("pasteFromSelection");`` which get content from [mode=QClipboard::Selection](http://doc.qt.io/qt-5/qclipboard.html#Mode-enum)

## Why
I believe (and according to Wikipedia) that X windows users primarily use the `Primary Selection` instead of the `clipboard`.

## Non-Linux Users?
**Nothing changed** for Windows and MacOS users.
Technically the mouse-up event is **captured by a different function** that will do nothing **as before**.
The code is at <https://github.com/scinart/anki/blob/1ecb17af8d9d613f011b17ed1ee4f30082baf6df/aqt/editor.py#L801-L802>.

## Other
The code in this pull request is licensed under the BSD three-clause license.