### PR TITLE
Sort addons by meta field

### DIFF
--- a/aqt/addons.py
+++ b/aqt/addons.py
@@ -35,7 +35,21 @@ class AddonManager:
             if not os.path.exists(os.path.join(path, "__init__.py")):
                 continue
             l.append(d)
-        return l
+
+        # os.listdir returns directories in arbitrary order
+        # in case a certain load order need to be enforced,
+        # the numeric "loadorder" property can be added to the
+        # meta json file of an add on.
+
+        loadorder = [
+            self.addonMeta(dir).get("loadorder") 
+            if "loadorder" in self.addonMeta(dir) else 9999
+            for dir in l
+                ]
+
+        sortedAddons = [dir for _,dir in sorted(zip(loadorder,l))]
+
+        return sortedAddons
 
     def managedAddons(self):
         return [d for d in self.allAddons()


### PR DESCRIPTION
In some cases, it might be useful to define the load order of add ons.
This change reads the optional "loadorder" field and loads plugins
appropriately. I was thinking about creating a GUI for this, but I don't
think that most users will benefit from that. 

@glutanimate and I are suspecting,
that load orders can cause issues when for instance HTML modifying add ons
are loaded in the wrong order, hence this pull request.