### PR TITLE
Extend Bridge class with new method that passes return value to JS

### DIFF
--- a/aqt/webview.py
+++ b/aqt/webview.py
@@ -25,6 +25,9 @@ class AnkiWebPage(QWebEnginePage):
             @pyqtSlot(str)
             def cmd(self, str):
                 self.onCmd(str)
+            @pyqtSlot(str, result=str)
+            def run(self, str):
+                return self.onCmd(str)
 
         self._bridge = Bridge()
         self._bridge.onCmd = self._onCmd
@@ -40,8 +43,10 @@ class AnkiWebPage(QWebEnginePage):
         script = QWebEngineScript()
         script.setSourceCode(js + '''
             var pycmd;
+            var pyrun;
             new QWebChannel(qt.webChannelTransport, function(channel) {
                 pycmd = channel.objects.py.cmd;
+                pyrun = channel.objects.py.run;
                 pycmd("domDone");
             });
         ''')
@@ -68,7 +73,7 @@ class AnkiWebPage(QWebEnginePage):
         return False
 
     def _onCmd(self, str):
-        self._onBridgeCmd(str)
+        return self._onBridgeCmd(str)
 
 # Main web view
 ##########################################################################
@@ -293,7 +298,7 @@ body {{ zoom: {}; {} }}
             self._domDone = True
             self._maybeRunActions()
         else:
-            self.onBridgeCmd(cmd)
+            return self.onBridgeCmd(cmd)
 
     def defaultOnBridgeCmd(self, cmd):
         print("unhandled bridge cmd:", cmd)


### PR DESCRIPTION
While putting the final touches on [Mouseover Dictionary](https://github.com/glutanimate/mouseover-dictionary) and porting the add-on to Anki 2.1, I ran into a roadblock with setting up a py<->js interface. On Anki 2.0 [I had been using `addToJavaScriptWindowObject`](https://github.com/glutanimate/mouseover-dictionary/blob/master/src/mouseover_dictionary/main.py#L73-L99) to expose a custom Python object in JS, but that method was longer available with QtWebEngine.

I tried the usual by monkey-patching AnkiWebPage, or trying to register my Python object with the QWebChannel at runtime, but none of these attempts were fruitful. So eventually I decided to work on a PR to address this.

At its core, this commit simply reintroduces the `py.run` command that was available in Anki 2.0. It adds a new `run` method to the Bridge class – exposed as `pyrun` in JavaScript – for which the return value is passed back to the JavaScript caller. In cases where simply calling a Python handler through `pycmd` is not enough this will allow add-on authors to set up an easy-to-use JS-Py interface.

 Here's how I made use of that in my add-on, for instance: [Python](https://github.com/glutanimate/mouseover-dictionary/blob/master/src/mouseover_dictionary/main.py#L210-L214) and [JavaScript](https://github.com/glutanimate/mouseover-dictionary/blob/master/src/mouseover_dictionary/web.py#L169-L175).