### PR TITLE
Revert debug console shortcut workaround

### DIFF
--- a/aqt/main.py
+++ b/aqt/main.py
@@ -701,7 +701,7 @@ title="%s" %s>%s</button>''' % (
 
     def setupKeys(self):
         globalShortcuts = [
-            ("Ctrl+Shift+;", self.onDebug),
+            ("Ctrl+:", self.onDebug),
             ("d", lambda: self.moveToState("deckBrowser")),
             ("s", self.onStudyKey),
             ("a", self.onAddCard),


### PR DESCRIPTION
Seems like the assignment to "Ctrl+:" is working again. N.B.: Only tested this on de_DE and en_US layouts.

cf. fb81f63fe32b62a2aa3c02131ec2d4d0faef866b