### PR TITLE
Feature Request: Add Delete Card action in Browser

### DIFF
--- a/designer/browser.ui
+++ b/designer/browser.ui
@@ -232,7 +232,7 @@
      <x>0</x>
      <y>0</y>
      <width>750</width>
-     <height>22</height>
+     <height>23</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuEdit">
@@ -293,6 +293,8 @@
     <addaction name="menuFlag"/>
     <addaction name="separator"/>
     <addaction name="action_Info"/>
+    <addaction name="separator"/>
+    <addaction name="actionDelete_Cards"/>
    </widget>
    <widget class="QMenu" name="menu_Notes">
     <property name="title">
@@ -585,6 +587,14 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+K</string>
+   </property>
+  </action>
+  <action name="actionDelete_Cards">
+   <property name="text">
+    <string>Delete</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+Del</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Hello

First of all, thanks a lot for this fantastic piece of software. I have gotten very good use out of it for quite a few years now.

As the title says, this is a feature request of sorts, the ability to delete cards from the browser.

An example of use case is as follows:

I have a vocabulary deck with ~25K notes. I recently created a new set of cards for them, which only plays audio. Only ~6K cards have audio, so now there's 19K empty cards in the DB. So far I've been getting around this with filters and such, but I'd like to be able to remove cards without removing the notes, so I can clean out the cruft whenever I want to create a set of cards from a subset of the notes in the deck.

If anything is unclear or there's something I can fix further, please let me know.