### PR TITLE
force mpv --keep-open=no

### DIFF
--- a/anki/mpv.py
+++ b/anki/mpv.py
@@ -73,6 +73,7 @@ class MPVBase:
         "--force-window=no",
         "--ontop",
         "--audio-display=no",
+        "--keep-open=no",
     ]
 
     def __init__(self, window_id=None, debug=False):


### PR DESCRIPTION
If `keep-open` is set to yes in a user's mpv config file, the end of the audio file will simply pause and mpv will never actually enter idle mode. This means you're unable to load any new audio files and thus will only have sound for the very first card. So the easy fix is to just force it to be no.