### PR TITLE
Replaced magic numbers for card an queue types where possible.

### DIFF
--- a/anki/cards.py
+++ b/anki/cards.py
@@ -34,8 +34,8 @@ class Card:
             self.id = timestampID(col.db, "cards")
             self.did = 1
             self.crt = intTime()
-            self.type = 0
-            self.queue = 0
+            self.type = CARD_TYPE_NEW
+            self.queue = QUEUE_TYPE_NEW
             self.ivl = 0
             self.factor = 0
             self.reps = 0
@@ -73,7 +73,7 @@ class Card:
         self.mod = intTime()
         self.usn = self.col.usn()
         # bug check
-        if self.queue == 2 and self.odue and not self.col.decks.isDyn(self.did):
+        if self.queue == QUEUE_TYPE_DUE and self.odue and not self.col.decks.isDyn(self.did):
             runHook("odueInvalid")
         assert self.due < 4294967296
         self.col.db.execute(
@@ -104,7 +104,7 @@ insert or replace into cards values
         self.mod = intTime()
         self.usn = self.col.usn()
         # bug checks
-        if self.queue == 2 and self.odue and not self.col.decks.isDyn(self.did):
+        if self.queue == QUEUE_TYPE_DUE and self.odue and not self.col.decks.isDyn(self.did):
             runHook("odueInvalid")
         assert self.due < 4294967296
         self.col.db.execute(

--- a/anki/consts.py
+++ b/anki/consts.py
@@ -56,6 +56,35 @@ SYNC_VER = 9
 
 HELP_SITE="http://ankisrs.net/docs/manual.html"
 
+# from card.py
+# Card and Queue types
+# Card Types
+# Type: 0=new, 1=learning, 2=due
+# Queue: same as above, and:
+#        -1=suspended, -2=user buried, -3=sched buried
+# Due is used differently for different queues.
+# - new queue: note id or random int
+# - rev queue: integer day
+# - lrn queue: integer timestamp
+
+# from sched.py
+# queue types: 0=new/cram, 1=lrn, 2=rev, 3=day lrn, -1=suspended, -2=buried
+# revlog types: 0=lrn, 1=rev, 2=relrn, 3=cram
+
+CARD_TYPE_NEW=0
+CARD_TYPE_LEARNING=1
+CARD_TYPE_DUE=2
+
+QUEUE_TYPE_SUSPENDED=-1
+QUEUE_TYPE_USER_BURIED=-2
+QUEUE_TYPE_SCHED_BURIED=-3
+QUEUE_TYPE_NEW=CARD_TYPE_NEW
+QUEUE_TYPE_LEARNING=CARD_TYPE_LEARNING
+QUEUE_TYPE_DUE=CARD_TYPE_DUE
+QUEUE_TYPE_DAY_LEARN=3
+QUEUE_TYPE_PREVIEW=4
+
+
 # Labels
 ##########################################################################
 


### PR DESCRIPTION
Created constants QUEUE_TYPE_* and CARD_TYPE_*
Note:
 - Undocumented card type 3
 - SQL still uses magic numbers, but modifying to use format strings could take a while, suggest switching to pewee ORM, to stop cluttering with error prone SQL.
http://docs.peewee-orm.com/en/latest/