### PR TITLE
Refine wording in Find duplicates

### DIFF
--- a/designer/finddupes.ui
+++ b/designer/finddupes.ui
@@ -22,14 +22,14 @@
      <item row="2" column="1">
       <widget class="QLabel" name="label_2">
        <property name="text">
-        <string>Optional limit:</string>
+        <string>Optional filter:</string>
        </property>
       </widget>
      </item>
      <item row="1" column="1">
       <widget class="QLabel" name="label">
        <property name="text">
-        <string>Look in field:</string>
+        <string>Search in:</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
A small improvement.
In Browser and other dialogues 'Search' and 'Filter' are used. Using the
same terms here make Find duplicates more intuitive