### PR TITLE
Increment cloze number correctly after removing cloze deletions

### DIFF
--- a/aqt/editor.py
+++ b/aqt/editor.py
@@ -54,6 +54,7 @@ class Editor:
         self.setupWeb()
         self.setupShortcuts()
         self.setupTags()
+        self._performCloze = False
 
     # Initial setup
     ############################################################
@@ -270,6 +271,9 @@ class Editor:
                 else:
                     self.checkValid()
             else:
+                if self._performCloze:
+                    self._onCloze()
+                    self._performCloze = False
                 runHook("editTimer", self.note)
                 self.checkValid()
         # focused into field?
@@ -482,6 +486,12 @@ class Editor:
 To make a cloze deletion on an existing note, you need to change it \
 to a cloze type first, via Edit>Change Note Type."""))
                 return
+        self._performCloze = True
+        self.web.eval('saveField("key")')
+
+    def _onCloze(self):
+        if not self._performCloze:
+            return
         # find the highest existing cloze
         highest = 0
         for name, val in list(self.note.items()):
@@ -494,6 +504,7 @@ to a cloze type first, via Edit>Change Note Type."""))
         # must start at 1
         highest = max(1, highest)
         self.web.eval("wrap('{{c%d::', '}}');" % highest)
+        self._performCloze = False
 
     # Foreground colour
     ######################################################################

--- a/web/editor.js
+++ b/web/editor.js
@@ -2,6 +2,7 @@ var currentField = null;
 var changeTimer = null;
 var dropTarget = null;
 var currentNoteId = null;
+var keepSelectionOnce = false;
 
 String.prototype.format = function () {
     var args = arguments;
@@ -128,7 +129,8 @@ function onFocus(elem) {
     pycmd("focus:" + currentFieldOrdinal());
     enableButtons();
     // don't adjust cursor on mouse clicks
-    if (mouseDown) {
+    if (mouseDown || keepSelectionOnce) {
+        keepSelectionOnce = false;
         return;
     }
     // do this twice so that there's no flicker on newer versions
@@ -149,10 +151,11 @@ function onFocus(elem) {
     }
 }
 
-function focusField(n) {
+function focusField(n, keepSelection) {
     if (n === null) {
         return;
     }
+    keepSelectionOnce = keepSelection;
     $("#f" + n).focus();
 }
 


### PR DESCRIPTION
Undoing/deleting a cloze deletion and quickly creating a new one increments the number incorrectly. Waiting for the key cmd before creating the cloze fixes this.