### PR TITLE
stdHtml: fix certain fonts not working on Linux

### DIFF
--- a/aqt/webview.py
+++ b/aqt/webview.py
@@ -225,7 +225,7 @@ border-radius:5px; font-family: Helvetica }"""
         else:
             buttonspec = ""
             family = self.font().family()
-            fontspec = 'font-size:14px;font-family:%s;'%\
+            fontspec = 'font-size:14px;font-family:"%s";'%\
                 family
         csstxt = "\n".join([self.bundledCSS("webview.css")]+
                            [self.bundledCSS(fname) for fname in css])


### PR DESCRIPTION
There's quotes around the font-family value for Windows and Mac - looks like somebody forgot to do it for Linux.