### PR TITLE
Add needed packages to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ pyaudio
 requests
 decorator
 markdown
+sip
+pyqt5==5.9


### PR DESCRIPTION
I had to install these to getting the app running from git. Apologies if they're not included in requirements.txt for a particular reason.

I also had to get nose to run the tests, but I'm not sure if dev dependencies are meant to be included in a requirements file (I'm a bit new to python dev).

These requirements are already covered by the outstanding pipenv pr if you end up going that way.