### PR TITLE
Add a hook to browser.onContextMenu for add-on authors

### DIFF
--- a/aqt/browser.py
+++ b/aqt/browser.py
@@ -461,6 +461,7 @@ class Browser(QMainWindow):
         m.addSeparator()
         for act in self.form.menu_Notes.actions():
             m.addAction(act)
+        runHook("browser.onContextMenu", self, m)
         m.exec_(QCursor.pos())
 
     def updateFont(self):


### PR DESCRIPTION
Just a small change that will grant add-on authors more flexibility in implementing custom context menu actions.

Hope it's OK submitting this, even though Anki 2.1 has hit RC.