### PR TITLE
Make sure to end model reset when prematurely returning from toggleField

### DIFF
--- a/aqt/browser.py
+++ b/aqt/browser.py
@@ -735,6 +735,7 @@ by clicking on one on the left."""))
         self.model.beginReset()
         if type in self.model.activeCols:
             if len(self.model.activeCols) < 2:
+                self.model.endReset()
                 return showInfo(_("You must have at least one column."))
             self.model.activeCols.remove(type)
             adding=False


### PR DESCRIPTION
Fixes an issue where Anki would stall after trying to remove the last browser column.