### PR TITLE
Set showInfo parent explicitly in in browser find and replace

### DIFF
--- a/aqt/browser.py
+++ b/aqt/browser.py
@@ -1709,7 +1709,7 @@ update cards set usn=?, mod=?, did=? where id in """ + scids,
             "%(a)d of %(b)d notes updated", len(sf)) % {
                 'a': changed,
                 'b': len(sf),
-            })
+            }, parent=self)
 
     def onFindReplaceHelp(self):
         openHelp("findreplace")


### PR DESCRIPTION
Fixes an issue where focus would be passed over to mw after longer find and replace processing times. Interestingly enough focus would not be lost when the find and replace action completed quickly enough. Might have something to do with mw.progress?

P.S.: I don't think I've ever seen the progress dialog show up on Linux (not in any type of scenario, and neither on 2.0 nor 2.1). Is this something you've run into before, or could it be specific to my distro/DE (KDE)?