### PR TITLE
Add hotkeys for "Invert Selection" and "Reschedule"

### DIFF
--- a/designer/browser.ui
+++ b/designer/browser.ui
@@ -324,6 +324,9 @@
    <property name="text">
     <string>&amp;Reschedule...</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+Alt+R</string>
+   </property>
   </action>
   <action name="actionSelectAll">
    <property name="text">
@@ -344,6 +347,9 @@
   <action name="actionInvertSelection">
    <property name="text">
     <string>&amp;Invert Selection</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Alt+S</string>
    </property>
   </action>
   <action name="actionFind">


### PR DESCRIPTION
Although probably not the most common actions in the browser, I think that both "Invert Selection" and "Reschedule" are still used frequently enough to profit from a hotkey assignment.

Tested the hotkeys across Kubuntu 18.04, Windows 10, and macOS Sierra. No apparent conflicts with global keyboard assignments.