### PR TITLE
Try to more closely imitate native widget theming on Linux

### DIFF
--- a/aqt/webview.py
+++ b/aqt/webview.py
@@ -213,20 +213,38 @@ class AnkiWebView(QWebEngineView):
 
     def stdHtml(self, body, css=[], js=["jquery.js"], head=""):
         if isWin:
-            buttonspec = "button { font-size: 12px; font-family:'Segoe UI'; }"
+            widgetspec = "button { font-size: 12px; font-family:'Segoe UI'; }"
             fontspec = 'font-size:12px;font-family:"Segoe UI";'
         elif isMac:
             family="Helvetica"
             fontspec = 'font-size:15px;font-family:"%s";'% \
                        family
-            buttonspec = """
+            widgetspec = """
 button { font-size: 13px; -webkit-appearance: none; background: #fff; border: 1px solid #ccc;
 border-radius:5px; font-family: Helvetica }"""
         else:
-            buttonspec = ""
+            palette = self.style().standardPalette()
             family = self.font().family()
-            fontspec = 'font-size:14px;font-family:"%s";'%\
-                family
+            color_hl = palette.color(QPalette.Highlight).name()
+            color_hl_txt = palette.color(QPalette.HighlightedText).name()
+            color_btn = palette.color(QPalette.Button).name()
+            fontspec = 'font-size:14px;font-family:"%s";'% family
+            widgetspec = """
+/* Buttons */
+button{ font-size:14px; -webkit-appearance:none; outline:0;
+        background-color: %(color_btn)s; border:1px solid rgba(0,0,0,.2);
+        border-radius:2px; height:24px; font-family:"%(family)s"; }
+button:focus{ border-color: %(color_hl)s }
+button:hover{ background-color:#fff }
+button:active, button:active:hover { background-color: %(color_hl)s; color: %(color_hl_txt)s;}
+/* Input field focus outline */
+textarea:focus, input:focus, input[type]:focus, .uneditable-input:focus,
+div[contenteditable="true"]:focus {   
+    outline: 0 none;
+    border-color: %(color_hl)s;
+}""" % {"family": family, "color_btn": color_btn,
+        "color_hl": color_hl, "color_hl_txt": color_hl_txt}
+        
         csstxt = "\n".join([self.bundledCSS("webview.css")]+
                            [self.bundledCSS(fname) for fname in css])
         jstxt = "\n".join([self.bundledScript("webview.js")]+
@@ -248,7 +266,7 @@ body {{ zoom: {}; {} }}
 </head>
 
 <body>{}</body>
-</html>""".format(self.title, self.zoomFactor(), fontspec, buttonspec, head, body)
+</html>""".format(self.title, self.zoomFactor(), fontspec, widgetspec, head, body)
         #print(html)
         self.setHtml(html)
 


### PR DESCRIPTION
There are currently a number of smaller inconsistencies between Anki's native Qt widgets and HTML UI elements on Linux which this PR seeks to address.

The two main modifications concern the theming of HTML buttons and entry fields which have been adjusted to more closely follow suit with the rest of the UI.

Here is a quick comparison between the styling on Ubuntu 18.04 **before**...:

![screenshot_20180830_232842](https://user-images.githubusercontent.com/5459332/44880479-da341980-acac-11e8-863c-1e6975d8d425.png)

![screenshot_20180830_232914](https://user-images.githubusercontent.com/5459332/44880482-dc967380-acac-11e8-97f4-3d4dbecff4cc.png)

![screenshot_20180830_232933](https://user-images.githubusercontent.com/5459332/44880485-e029fa80-acac-11e8-894f-9010598deb22.png)

![screenshot_20180830_232942](https://user-images.githubusercontent.com/5459332/44880488-e1f3be00-acac-11e8-9142-d8d1e6fdf2a8.png)

...and **after** the commit:

![screenshot_20180830_233050](https://user-images.githubusercontent.com/5459332/44880494-e91acc00-acac-11e8-8777-8264681fc7eb.png)

![screenshot_20180830_233103](https://user-images.githubusercontent.com/5459332/44880501-ecae5300-acac-11e8-87b9-64844fcc6697.png)

Although not perfect, I think it's fair to say that the updated theming offers a more native-looking experience. As the colors of the HTML elements are drawn from the theme's standard palette this should  work reasonably well across most styles.

The implementation might need some work still as it currently queries the colors every time stdHtml is set, but I didn't want to perform any more extensive changes before submitting this PR for review.

FWIW: It seems like the focus outline colors are also off on Windows (macOS looks pretty native), so perhaps it might be worthwhile to apply some of these changes there as well.