### PR TITLE
Adds support for Base64 encoded images

### DIFF
--- a/anki/media.py
+++ b/anki/media.py
@@ -249,6 +249,8 @@ create table meta (dirMod int, lastUsn int); insert into meta values (0, 0);
             fname = match.group("fname")
             if re.match("(https?|ftp)://", fname):
                 return tag
+            if re.match("data:image", fname):
+                return tag
             return tag.replace(fname, fn(fname))
         for reg in self.imgRegexps:
             string = re.sub(reg, repl, string)

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -120,3 +120,11 @@ def test_illegal():
             assert(c not in good)
         else:
             assert(c in good)
+
+def test_base64_img():
+    d = getEmptyCol()
+    base64_str = """
+    <img src="data:image/png;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2w" />
+    """
+    escaped_str = d.media.escapeImages(base64_str)
+    assert escaped_str == base64_str


### PR DESCRIPTION
Images in cards with data:image urls were being escaped, meaning that
the data urls were not being correctly parsed by the web handler. This
change adds an exception to the escaping for data:image base64 encoded
images so that they can be properly displayed.