### PR TITLE
Use correct test binary on Ubuntu 18LTS

### DIFF
--- a/tools/tests.sh
+++ b/tools/tests.sh
@@ -8,6 +8,13 @@
 BIN="$(cd "`dirname "$0"`"; pwd)"
 export PYTHONPATH=${BIN}/..:${PYTHONPATH}
 
+# Default tools installation docs on Ubuntu results in "nosetests3" vs "nosetests"
+NOSETESTS=nosetests
+`which $NOSETESTS` > /dev/null 2>&1
+if [ "$?" == 1 ]; then
+    NOSETESTS=nosetests3
+fi
+
 dir=.
 
 if [ x$1 = x ]; then
@@ -22,4 +29,4 @@ else
     args=""
     echo "Call with coverage=1 to run coverage tests"
 fi
-(cd $dir && nosetests -vs --processes=16 --process-timeout=300 $lim $args --cover-package=anki)
+(cd $dir && $NOSETESTS -vs --processes=16 --process-timeout=300 $lim $args --cover-package=anki)


### PR DESCRIPTION
Pretty minor but I always start with testing working out of the box then go from there...

After following the installation instructions, I end
up with nosetests3 vs nosetests, this should make it
so whichever one you have, it will work out of the box

Should be backwards-compatible