### PR TITLE
Use beautifulsoup4 instead of bs4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bs4
+beautifulsoup4
 send2trash
 pyaudio
 requests


### PR DESCRIPTION
`bs4` is just a dummy package to prevent name squatting, it pulls in `beautifulsoup4` as a dependency.

https://incolumitas.com/2016/06/08/typosquatting-package-managers/

I’ve tested this, Anki runs fine. The import is still named `bs4` though, so no further edits are required.