### PR TITLE
Allow add-on authors to more easily extend Anki's web views

### DIFF
--- a/aqt/browser.py
+++ b/aqt/browser.py
@@ -1343,7 +1343,11 @@ where id in %s""" % ids2str(sf))
                  "reviewer.js"]
         self._previewWeb.stdHtml(self.mw.reviewer.revHtml(),
                                  css=["reviewer.css"],
-                                 js=jsinc)
+                                 js=jsinc,
+                                 head=runFilter("previewWebHead", "", self),
+                                 prefix=runFilter("previewWebPrefix", "", self),
+                                 suffix=runFilter("previewWebSuffix", "", self)
+                                 )
 
 
     def _renderPreview(self, cardChanged=False):

--- a/aqt/clayout.py
+++ b/aqt/clayout.py
@@ -187,10 +187,16 @@ class CardLayout(QDialog):
                  "reviewer.js"]
         pform.frontWeb.stdHtml(self.mw.reviewer.revHtml(),
                                css=["reviewer.css"],
-                               js=jsinc)
+                               js=jsinc,
+                               head=runFilter("cardlayoutWebHead", "", self),
+                               prefix=runFilter("cardlayoutWebPrefix", "", self),
+                               suffix=runFilter("cardlayoutWebSuffix", "", self))
         pform.backWeb.stdHtml(self.mw.reviewer.revHtml(),
                               css=["reviewer.css"],
-                               js=jsinc)
+                              js=jsinc,
+                              head=runFilter("cardlayoutWebHead", "", self),
+                              prefix=runFilter("cardlayoutWebPrefix", "", self),
+                              suffix=runFilter("cardlayoutWebSuffix", "", self))
 
     def updateMainArea(self):
         if self._isCloze():

--- a/aqt/deckbrowser.py
+++ b/aqt/deckbrowser.py
@@ -9,7 +9,7 @@ from anki.utils import isMac, ids2str, fmtTimeSpan
 from anki.errors import DeckRenameError
 import aqt
 from anki.sound import clearAudioQueue
-from anki.hooks import runHook
+from anki.hooks import runHook, runFilter
 from copy import deepcopy
 
 class DeckBrowser:
@@ -88,11 +88,14 @@ class DeckBrowser:
 
     def __renderPage(self, offset):
         tree = self._renderDeckTree(self._dueTree)
-        stats = self._renderStats()
-        self.web.stdHtml(self._body%dict(
+        stats = runFilter("deckBrowserWebStats", self._renderStats(), self)
+        self.web.stdHtml(self._body % dict(
             tree=tree, stats=stats, countwarn=self._countWarn()),
                          css=["deckbrowser.css"],
-                         js=["jquery.js", "jquery-ui.js", "deckbrowser.js"])
+                         js=["jquery.js", "jquery-ui.js", "deckbrowser.js"],
+                         head=runFilter("deckbrowserWebHead", "", self),
+                         prefix=runFilter("deckbrowserWebPrefix", "", self),
+                         suffix=runFilter("deckbrowserWebSuffix", "", self))
         self.web.key = "deckBrowser"
         self._drawButtons()
         self._scrollToOffset(offset)

--- a/aqt/editor.py
+++ b/aqt/editor.py
@@ -112,7 +112,10 @@ class Editor:
             topbuts,
             _("Show Duplicates")),
                          css=["editor.css"],
-                         js=["jquery.js", "editor.js"])
+                         js=["jquery.js", "editor.js"],
+                         head=runFilter("editorWebHead", "", self),
+                         prefix=runFilter("editorWebPrefix", "", self),
+                         suffix=runFilter("editorWebSuffix", "", self))
 
     # Top buttons
     ######################################################################

--- a/aqt/overview.py
+++ b/aqt/overview.py
@@ -6,6 +6,7 @@ from aqt.utils import openLink, shortcut, tooltip, askUserDialog
 from anki.utils import isMac
 import aqt
 from anki.sound import clearAudioQueue
+from anki.hooks import runFilter
 
 class Overview:
     "Deck overview."
@@ -133,10 +134,15 @@ class Overview:
                 deck=deck['name'],
                 shareLink=shareLink,
                 desc=self._desc(deck),
-                table=self._table()
+                table=self._table(),
+                stats=runFilter("overviewWebStats", "", self)
             ),
                          css=["overview.css"],
-                         js=["jquery.js", "overview.js"])
+                         js=["jquery.js", "overview.js"],
+                         head=runFilter("overviewWebHead", "", self),
+                         prefix=runFilter("overviewWebPrefix", "", self),
+                         suffix=runFilter("overviewWebSuffix", "", self)
+        )
 
     def _desc(self, deck):
         if deck['dyn']:
@@ -193,6 +199,7 @@ to their original deck.""")
 %(shareLink)s
 %(desc)s
 %(table)s
+%(stats)s
 </center>
 """
 

--- a/aqt/reviewer.py
+++ b/aqt/reviewer.py
@@ -139,13 +139,20 @@ class Reviewer:
                              "browsersel.js",
                              "mathjax/conf.js",
                              "mathjax/MathJax.js",
-                             "reviewer.js"])
+                             "reviewer.js"],
+                         head=runFilter("reviewerWebHead", "", self),
+                         prefix=runFilter("reviewerWebPrefix", "", self),
+                         suffix=runFilter("reviewerWebSuffix", "", self)
+                         )
         # show answer / ease buttons
         self.bottom.web.show()
         self.bottom.web.stdHtml(
             self._bottomHTML(),
             css=["toolbar-bottom.css", "reviewer-bottom.css"],
-            js=["jquery.js", "reviewer-bottom.js"]
+            js=["jquery.js", "reviewer-bottom.js"],
+            head=runFilter("reviewerBottomWebHead", "", self),
+            prefix=runFilter("reviewerBottomWebPrefix", "", self),
+            suffix=runFilter("reviewerBottomWebSuffix", "", self)
         )
 
     # Showing the question

--- a/aqt/stats.py
+++ b/aqt/stats.py
@@ -7,6 +7,7 @@ import os, time
 from aqt.utils import saveGeom, restoreGeom, maybeHideClose, addCloseShortcut, \
     tooltip, getSaveFile
 import aqt
+from anki.hooks import runFilter
 
 # Deck Stats
 ######################################################################
@@ -83,5 +84,8 @@ class DeckStats(QDialog):
         stats.wholeCollection = self.wholeCollection
         self.report = stats.report(type=self.period)
         self.form.web.stdHtml("<html><body>"+self.report+"</body></html>",
-                              js=["jquery.js", "plot.js"])
+                              js=["jquery.js", "plot.js"],
+                              head=runFilter("statsWebHead", "", self),
+                              prefix=runFilter("statsWebPrefix", "", self),
+                              suffix=runFilter("statsWebSuffix", "", self))
         self.mw.progress.finish()

--- a/aqt/toolbar.py
+++ b/aqt/toolbar.py
@@ -4,6 +4,8 @@
 
 from aqt.qt import *
 
+from anki.hooks import runFilter
+
 class Toolbar:
 
     def __init__(self, mw, web):
@@ -22,7 +24,10 @@ class Toolbar:
     def draw(self):
         self.web.onBridgeCmd = self._linkHandler
         self.web.stdHtml(self._body % self._centerLinks(),
-                         css=["toolbar.css"])
+                         css=["toolbar.css"],
+                         head=runFilter("toolbarWebHead", "", self),
+                         prefix=runFilter("toolbarWebPrefix", "", self),
+                         suffix=runFilter("toolbarWebSuffix", "", self))
         self.web.adjustHeightToFit()
 
     # Available links
@@ -103,5 +108,8 @@ class BottomBar(Toolbar):
         self.web.onBridgeCmd = self._linkHandler
         self.web.stdHtml(
             self._centerBody % buf,
-            css=["toolbar.css", "toolbar-bottom.css"])
+            css=["toolbar.css", "toolbar-bottom.css"],
+            head=runFilter("bottombarWebHead", "", self),
+            prefix=runFilter("bottombarWebPrefix", "", self),
+            suffix=runFilter("bottombarWebSuffix", "", self))
         self.web.adjustHeightToFit()

--- a/aqt/webview.py
+++ b/aqt/webview.py
@@ -211,7 +211,8 @@ class AnkiWebView(QWebEngineView):
         else:
             return 3
 
-    def stdHtml(self, body, css=[], js=["jquery.js"], head=""):
+    def stdHtml(self, body, css=[], js=["jquery.js"], head="",
+                prefix="", suffix=""):
         if isWin:
             widgetspec = "button { font-size: 12px; font-family:'Segoe UI'; }"
             fontspec = 'font-size:12px;font-family:"Segoe UI";'
@@ -265,8 +266,9 @@ body {{ zoom: {}; {} }}
 {}
 </head>
 
-<body>{}</body>
-</html>""".format(self.title, self.zoomFactor(), fontspec, widgetspec, head, body)
+<body>{}{}{}</body>
+</html>""".format(self.title, self.zoomFactor(), fontspec, widgetspec, head,
+                  prefix, body, suffix)
         #print(html)
         self.setHtml(html)
 


### PR DESCRIPTION
Extends all pertinent web views with runFilter hooks that enable add-on authors to easily prepend and append HTML to the body of the view, or add their own CSS or JS to the head element.

Also implements two runFilter hooks specific to the stats areas of the Overview and DeckBrowser, granting more control over these commonly modified parts of Anki's UI.

These changes should help alleviate some of the conflicts between add-ons that target the same HTML views, and also do away with some of the hacks that are currently in use to achieve similar
goals.

----

I've been meaning to submit something like this for a while now. What prompted me to finally work on these changes is an old issue that recently resurfaced in my efforts to refactor and port Review Heatmap to 2.1: Review Heatmap extends Anki's Overview and DeckBrowser screens with a custom element showcasing user activity over time. For the DeckBrowser screen this element is positioned right below the stats area. For the Overview screen it's right below the table element.

The main challenge I initially faced when modifying these parts of Anki's user interface was that they were also commonly targeted by other add-ons. So users installing an add-on like More Overview Stats would suddenly see their heatmap disappear, as the _table() function I was wrapping to add my heatmap would be overwritten by the other add-on. This forced me to move to a more hacky and unstable implementation in the form of completely [overwriting Overview._renderPage()](https://github.com/glutanimate/review-heatmap/blob/master/src/review_heatmap/main.py#L272-L316) and [Overview._body](https://github.com/glutanimate/review-heatmap/blob/master/src/review_heatmap/web.py#L319-L328). To this day this is how Review Heatmap works on the Deck screen. Needless to say, this in turn has been the cause of many incompatibilities with other add-ons, e.g. Night Mode.

My first hope with this PR is that the changes will allow add-on authors to modify Anki's web elements less intrusively. My second hope is that it will make the web part of add-on development more accessible in general.

To test these changes in practice I've also compiled a quick proof-of-concept add-on that is available [here](https://gist.github.com/glutanimate/b5c16c7e5bc3b96e7388af767bfd6080).