### PR TITLE
Change the order of elements on the window title

### DIFF
--- a/aqt/main.py
+++ b/aqt/main.py
@@ -248,7 +248,7 @@ close the profile or restart Anki."""))
             restoreGeom(self, "mainWindow")
             restoreState(self, "mainWindow")
         # titlebar
-        self.setWindowTitle("Anki - " + self.pm.name)
+        self.setWindowTitle(self.pm.name + " - Anki")
         # show and raise window for osx
         self.show()
         self.activateWindow()


### PR DESCRIPTION
The application name typically comes at the end of the title. As such, many tools grabs the string after '-' as the application name. What Anki does currently causes the profile name to be grabbed, producing unexpected results.