### PR TITLE
JSON:dealing with configurations which are not dictionnaries

### DIFF
--- a/aqt/addons.py
+++ b/aqt/addons.py
@@ -495,6 +495,9 @@ class ConfigEditor(QDialog):
         txt = self.form.editor.toPlainText()
         try:
             new_conf = json.loads(txt)
+            if not isinstance(new_conf, dict):
+                showInfo(_("Invalid configuration: Configurations should be dictionnaries."))
+                return
         except Exception as e:
             showInfo(_("Invalid configuration: ") + repr(e))
             return


### PR DESCRIPTION
Currently, anki's add-on manager accept configurations which are valid json but which are not dictionaries. Which then leads to a bug when anki tries to display the new configuration, since anki except a dictionary. 
In order to be consistent with the documentation, which requires that configurations to be dictionaries, I edited your code to reject configurations which are not actually dictionaries.