### PR TITLE
Change order of new cards

### DIFF
--- a/anki/sched.py
+++ b/anki/sched.py
@@ -352,7 +352,7 @@ did = ? and queue = 0 limit ?)""", did, lim)
             if lim:
                 # fill the queue with the current did
                 self._newQueue = self.col.db.list("""
-select id from cards where did = ? and queue = 0 order by due limit ?""", did, lim)
+                select id from cards where did = ? and queue = 0 order by due,ord limit ?""", did, lim)
                 if self._newQueue:
                     self._newQueue.reverse()
                     return True

--- a/anki/schedv2.py
+++ b/anki/schedv2.py
@@ -353,7 +353,7 @@ did = ? and queue = 0 limit ?)""", did, lim)
             if lim:
                 # fill the queue with the current did
                 self._newQueue = self.col.db.list("""
-select id from cards where did = ? and queue = 0 order by due limit ?""", did, lim)
+                select id from cards where did = ? and queue = 0 order by due,ord limit ?""", did, lim)
                 if self._newQueue:
                     self._newQueue.reverse()
                     return True


### PR DESCRIPTION
This commit corrects the following bug:

* Create a note N in an empty deck D of type basic (reverse), with
only some back, no front. Only card 2 will be generated.
* Edit the note, add a front. Card 1 will be generated.
* In the main window, try to learn deck D. In anki, currently, you'll
  see Card 2 first. According to the manual (and to my common sens),
  it should be Card 1 first.

This commit correct this bug, and ensure that new cards are seen
according to their order, and not to their creation date.