### PR TITLE
Using cardIds in AnkiExporter

### DIFF
--- a/anki/exporting.py
+++ b/anki/exporting.py
@@ -125,10 +125,7 @@ class AnkiExporter(Exporter):
         self.dst = Collection(path)
         self.src = self.col
         # find cards
-        if not self.did:
-            cids = self.src.db.list("select id from cards")
-        else:
-            cids = self.src.decks.cids(self.did, children=True)
+        cids = self.cardIds()
         # copy cards, noting used nids
         nids = {}
         data = []


### PR DESCRIPTION
The main point of this pull request is to allow me to simplify the code of the add-on https://ankiweb.net/shared/info/1983204951
As far as I can tell, the four deleted lines of anki.exporting.py's method AnkiExporter.exportInto are almost what is already defined in cardIds. The only difference between those four lines  being that cardIds set self.count. Since AnkiExporter.exportInto set self.count later, without reading its value, this difference has no consequence.
Using cardIds seems better to me than the current solution, because if an add-on redefine cardIds (which is exactly what my add-on do), the modification will be applied to every exporting methods, and not to only two of them.

As a side note, I believe you may want to warn when you export a card without exporting its sibling in a apkg file. Because, when the user import the deck, the missing siblings will be generated as new cards, which may be unexpected. And the problem may be hard to detect.