### PR TITLE
Close deck chooser without changing the deck

### DIFF
--- a/aqt/deckchooser.py
+++ b/aqt/deckchooser.py
@@ -75,7 +75,8 @@ class DeckChooser(QHBoxLayout):
             self.mw, current=current, accept=_("Choose"),
             title=_("Choose Deck"), help="addingnotes",
             cancel=False, parent=self.widget, geomKey="selectDeck")
-        self.setDeckName(ret.name)
+        if ret.name:
+            self.setDeckName(ret.name)
 
     def setDeckName(self, name):
         self.deck.setText(name.replace("&", "&&"))

--- a/aqt/studydeck.py
+++ b/aqt/studydeck.py
@@ -114,8 +114,6 @@ class StudyDeck(QDialog):
     def reject(self):
         saveGeom(self, self.geomKey)
         remHook('reset', self.onReset)
-        if not self.cancel:
-            return self.accept()
         QDialog.reject(self)
 
     def onAddDeck(self):


### PR DESCRIPTION
Issue: Add a new card, open the deck chooser, type something in, and press escape. Instead of just closing the dialog, it switches to whichever deck is selected.