### PR TITLE
The note in curentEdit is not changed until the window is closed.

### DIFF
--- a/aqt/__init__.py
+++ b/aqt/__init__.py
@@ -49,6 +49,7 @@ from anki.utils import checksum
 # -- setting silentlyClose=True to have it close immediately
 # -- define a closeWithCallback() method
 # - have the window opened via aqt.dialogs.open(<name>, self)
+# - have a method reopen(*args), called if the user ask to open the window a second time. Arguments passed are the same than for original opening.
 
 #- make preferences modal? cmd+q does wrong thing
 
@@ -74,6 +75,8 @@ class DialogManager:
                 instance.setWindowState(instance.windowState() & ~Qt.WindowMinimized)
             instance.activateWindow()
             instance.raise_()
+            if hasattr(instance,"reopen"):
+                instance.reopen(*args)
             return instance
         else:
             instance = creator(*args)

--- a/aqt/editcurrent.py
+++ b/aqt/editcurrent.py
@@ -3,10 +3,12 @@
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 from aqt.qt import *
+from aqt.utils import tooltip
 import aqt.editor
 from aqt.utils import saveGeom, restoreGeom
 from anki.hooks import addHook, remHook
 from anki.utils import isMac
+
 
 class EditCurrent(QDialog):
 
@@ -34,8 +36,8 @@ class EditCurrent(QDialog):
     def onReset(self):
         # lazy approach for now: throw away edits
         try:
-            n = self.mw.reviewer.card.note()
-            n.load()
+            n = self.editor.note
+            n.load()#reload in case the model changed
         except:
             # card's been deleted
             remHook("reset", self.onReset)
@@ -46,6 +48,10 @@ class EditCurrent(QDialog):
             return
         self.editor.setNote(n)
 
+    def reopen(self,mw):
+        tooltip("Please finish editing the existing card first.")
+        self.onReset()
+        
     def reject(self):
         self.saveAndClose()
 


### PR DESCRIPTION
https://anki.tenderapp.com/discussions/ankidesktop/31105-reopening-an-edit-window
I added a «reopen» method, which I believe may be useful in other
cases too. I check whether the method exists before calling it, so
there should be no compatibility problem.