### PR TITLE
Fix searching for python 3.7

### DIFF
--- a/anki/find.py
+++ b/anki/find.py
@@ -440,7 +440,7 @@ select distinct(n.id) from cards c, notes n where c.nid=n.id and """+preds
             # nothing has that field
             return
         # gather nids
-        regex = re.escape(val).replace("_", ".").replace(re.escape('%'), ".*")
+        regex = re.escape(val).replace("_", ".").replace(re.escape("%"), ".*")
         nids = []
         for (id,mid,flds) in self.col.db.execute("""
 select id, mid, flds from notes

--- a/anki/find.py
+++ b/anki/find.py
@@ -440,7 +440,7 @@ select distinct(n.id) from cards c, notes n where c.nid=n.id and """+preds
             # nothing has that field
             return
         # gather nids
-        regex = re.escape(val).replace("_", ".").replace("\\%", ".*")
+        regex = re.escape(val).replace("_", ".").replace(re.escape('%'), ".*")
         nids = []
         for (id,mid,flds) in self.col.db.execute("""
 select id, mid, flds from notes


### PR DESCRIPTION
3.7 introduced a change to `re.escape()`, which no longer escapes `%`. By using `re.escape("%")` instead of a literal, we can detect a proper form at runtime.