### PR TITLE
Remove <br> from empty fields.

### DIFF
--- a/aqt/editor.py
+++ b/aqt/editor.py
@@ -254,7 +254,6 @@ class Editor:
                 return
             txt = urllib.parse.unquote(txt)
             txt = unicodedata.normalize("NFC", txt)
-            txt = self.mungeHTML(txt)
             # misbehaving apps may include a null byte in the text
             txt = txt.replace("\x00", "")
             # reverse the url quoting we added to get images to display
@@ -285,10 +284,6 @@ class Editor:
             self._links[cmd](self)
         else:
             print("uncaught cmd", cmd)
-
-    def mungeHTML(self, txt):
-        txt = re.sub(r"<br>$", "", txt)
-        return txt
 
     # Setting/unsetting the current note
     ######################################################################

--- a/web/editor.css
+++ b/web/editor.css
@@ -5,7 +5,9 @@
     padding: 5px;
     overflow-wrap: break-word;
 }
-
+.field:empty:before {
+    content: "\00a0"; /* nbsp */
+}
 .clearfix:after {
     content: "";
     display: table;

--- a/web/editor.js
+++ b/web/editor.js
@@ -87,11 +87,6 @@ function inPreEnvironment() {
 }
 
 function onInput() {
-    // empty field?
-    if (currentField.innerHTML === "") {
-        currentField.innerHTML = "<br>";
-    }
-
     // make sure IME changes get saved
     triggerKeyTimer();
 }
@@ -292,9 +287,6 @@ function setFields(fields) {
     for (var i = 0; i < fields.length; i++) {
         var n = fields[i][0];
         var f = fields[i][1];
-        if (!f) {
-            f = "<br>";
-        }
         txt += "<tr><td class=fname>{0}</td></tr><tr><td width=100%>".format(n);
         txt += "<div id=f{0} onkeydown='onKey();' oninput='onInput()' onmouseup='onKey();'".format(i);
         txt += " onfocus='onFocus(this);' onblur='onBlur();' class='field clearfix' ";


### PR DESCRIPTION
Fixes a minor issue when you remove all text and undo. It prepends a <br> tag (try C-A, Delete, C-Z). Instead of using the placeholder tag, this uses CSS.