### PR TITLE
Fix crash caused by cutting and copying events that don't modify the clipboard

### DIFF
--- a/aqt/editor.py
+++ b/aqt/editor.py
@@ -971,6 +971,8 @@ class EditorWebView(AnkiWebView):
         # add a comment in the clipboard html so we can tell text is copied
         # from us and doesn't need to be stripped
         clip = self.editor.mw.app.clipboard()
+        if not clip.ownsClipboard():
+            return
         mime = clip.mimeData()
         if not mime.hasHtml():
             return


### PR DESCRIPTION
1. Add a new card.
2. Select no text in a field and press Ctrl-X or Ctrl-C.
3. Copy text in another application. It only works for some (eg Chrome).

It crashes:

```
qt: OleSetClipboard: Failed to set mime data () on clipboard: COM error 0xffffffff800401d4  (Unknown error 0x0800401d4)
```

`Editor.cutOrCopy()` sets `self._markInternal = True`, so Anki attempts to edit clipboard contents from another source the next time something is copied or cut, which may cause a crash.

My solution is to test whether Anki owns the clipboard content. I wasn't able to access the clipboard contents in editor.js, and prevent the event from being fired for empty strings.