### PR TITLE
Add support for button icons stored in Qt resource system

### DIFF
--- a/aqt/editor.py
+++ b/aqt/editor.py
@@ -145,7 +145,9 @@ class Editor:
     def _addButton(self, icon, cmd, tip="", label="", id=None, toggleable=False,
                    disables=True):
         if icon:
-            if os.path.isabs(icon):
+            if icon.startswith("qrc:/"):
+                iconstr = icon
+            elif os.path.isabs(icon):
                 iconstr = self.resourceToData(icon)
             else:
                 iconstr = "/_anki/imgs/{}.png".format(icon)


### PR DESCRIPTION
Just a small change to Editor._addButton that will allow add-on developers to utilize images in the Qt resource system.