### PR TITLE
Permit use of codebase without portaudio lib installed

### DIFF
--- a/anki/sound.py
+++ b/anki/sound.py
@@ -297,10 +297,15 @@ addHook("unloadProfile", stopMplayer)
 # PyAudio recording
 ##########################################################################
 
-import pyaudio
+# Allow use of codebase without portaudio library.
+try:
+    import pyaudio
+    PYAU_FORMAT = pyaudio.paInt16
+except ImportError:
+    pass
+
 import wave
 
-PYAU_FORMAT = pyaudio.paInt16
 PYAU_CHANNELS = 1
 PYAU_INPUT_INDEX = None
 


### PR DESCRIPTION
First off, thanks for making this software available, and being so generous with your time :)

I am trying to using the import/export libraries in custom command-line tool. I am able to import anki as a library just fine, but the requirement to install system-level packages like portaudio means the tool will have a more burdensome install process.

Would it be acceptable to allow the package to run without pyaudio package compilation being a requirement? Thanks!