### PR TITLE
Address PyPI PyQt 5.12 packaging changes

### DIFF
--- a/README.development
+++ b/README.development
@@ -28,7 +28,7 @@ pyqt5-dev-tools) as well.
 If you're on another platform or your distro has the wrong Qt version, you
 can install PyQt with pip:
 
-$ pip3 install sip pyqt5
+$ pip3 install PyQt5 PyQtWebEngine
 
 To use the development version:
 

--- a/aqt/qt.py
+++ b/aqt/qt.py
@@ -13,7 +13,7 @@ from anki.utils import isWin, isMac
 from PyQt5.Qt import *
 # trigger explicit message in case of missing libraries
 # instead of silently failing to import
-from PyQt5.QtWebEngineWidgets import QWebEnginePage
+from PyQt5.QtWebEngineWidgets import *
 try:
     from PyQt5 import sip
 except ImportError:


### PR DESCRIPTION
This PR addresses a series of changes recently introduced with the release of PyQt 5.12 on PyPI.

WebEngine is now packaged separately as PyQtWebEngine. While the [changelog](https://www.riverbankcomputing.com/news/pyqt-512) states that this should have no effects beyond packaging, it seems like the existing imports in the qt module are no longer sufficient to cover modules like `QWebEngineView` (producing NameErrors).

The second commit in this PR seeks to fix that by importing all from QtWebEngineWidgets.