### PR TITLE
Correct Deck in card preview

### DIFF
--- a/anki/collection.py
+++ b/anki/collection.py
@@ -437,10 +437,12 @@ insert into cards values (?,?,?,?,?,?,0,0,?,0,0,0,0,0,0,0,0,"")""",
         card.nid = note.id
         card.ord = template['ord']
         # Use template did (deck override) if valid, otherwise model did
-        if template['did'] and str(template['did']) in self.decks.decks:
-            card.did = template['did']
-        else:
-            card.did = note.model()['did']
+        card.did = self.db.scalar("select did from cards where nid = ? and ord = ?", card.nid, card.ord)
+        if not card.did:
+            if template['did'] and str(template['did']) in self.decks.decks:
+                card.did = template['did']
+            else:
+                card.did = note.model()['did']
         # if invalid did, use default instead
         deck = self.decks.get(card.did)
         if deck['dyn']:

--- a/anki/collection.py
+++ b/anki/collection.py
@@ -417,7 +417,7 @@ insert into cards values (?,?,?,?,?,?,0,0,?,0,0,0,0,0,0,0,0,"")""",
     # type 0 - when previewing in add dialog, only non-empty
     # type 1 - when previewing edit, only existing
     # type 2 - when previewing in models dialog, all templates
-    def previewCards(self, note, type=0):
+    def previewCards(self, note, type=0, did = None):
         if type == 0:
             cms = self.findTemplates(note)
         elif type == 1:
@@ -428,19 +428,21 @@ insert into cards values (?,?,?,?,?,?,0,0,?,0,0,0,0,0,0,0,0,"")""",
             return []
         cards = []
         for template in cms:
-            cards.append(self._newCard(note, template, 1, flush=False))
+            cards.append(self._newCard(note, template, 1, flush=False, did = did))
         return cards
 
-    def _newCard(self, note, template, due, flush=True):
+    def _newCard(self, note, template, due, did = None, flush=True):
         "Create a new card."
         card = anki.cards.Card(self)
         card.nid = note.id
         card.ord = template['ord']
-        # Use template did (deck override) if valid, otherwise model did
         card.did = self.db.scalar("select did from cards where nid = ? and ord = ?", card.nid, card.ord)
+        # Use template did (deck override) if valid, otherwise did in argument, otherwise model did
         if not card.did:
             if template['did'] and str(template['did']) in self.decks.decks:
                 card.did = template['did']
+            elif did:
+                card.did = did
             else:
                 card.did = note.model()['did']
         # if invalid did, use default instead

--- a/aqt/about.py
+++ b/aqt/about.py
@@ -117,6 +117,7 @@ system. It's free and open source.")
         "黃文龍",
         "David Bailey",
         "Arman High",
+        "Arthur Milchior",
 ))
 
     abouttext += '<p>' + _("Written by Damien Elmes, with patches, translation,\

--- a/aqt/clayout.py
+++ b/aqt/clayout.py
@@ -61,7 +61,8 @@ class CardLayout(QDialog):
         self.setFocus()
 
     def redraw(self):
-        self.cards = self.col.previewCards(self.note, 2)
+        did = self.parent.deckChooser.selectedId() if self.addMode else None
+        self.cards = self.col.previewCards(self.note, 2, did = did)
         idx = self.ord
         if idx >= len(self.cards):
             self.ord = len(self.cards) - 1

--- a/aqt/clayout.py
+++ b/aqt/clayout.py
@@ -61,7 +61,9 @@ class CardLayout(QDialog):
         self.setFocus()
 
     def redraw(self):
-        did = self.parent.deckChooser.selectedId() if self.addMode else None
+        did = None
+        if hasattr(self.parent,"deckChooser"):
+                did = self.parent.deckChooser.selectedId()
         self.cards = self.col.previewCards(self.note, 2, did = did)
         idx = self.ord
         if idx >= len(self.cards):


### PR DESCRIPTION
This pull request is essentially the same thing than add-on https://ankiweb.net/shared/info/1658360602
If you use {{deck}} in a card type, and then open the model editor, the preview show a wrong value for deck. 

I correct this in two ways.
If the card exists in the database, I use its real deck.

If the note type editor is opened from the addcard window, then I check the addcard's deck value.

This is done by adding new optional parameters to methods, so it should not interact too much with other add-on calling those methods. 

Furthermore, I also add myself to the list of contributor.