### PR TITLE
Error dialog tweaks

### DIFF
--- a/aqt/errors.py
+++ b/aqt/errors.py
@@ -130,7 +130,7 @@ add-ons section</a> of our support site.
         error = self._supportText() + "\n" + error
 
         txt = txt + "<div style='white-space: pre-wrap'>" + error + "</div>"
-        showText(txt, type="html")
+        showText(txt, type="html", copyBtn=True)
 
     def _supportText(self):
         import platform

--- a/aqt/utils.py
+++ b/aqt/utils.py
@@ -50,7 +50,7 @@ def showInfo(text, parent=False, help="", type="info", title="Anki"):
     return mb.exec_()
 
 def showText(txt, parent=None, type="text", run=True, geomKey=None, \
-        minWidth=500, minHeight=400, title="Anki"):
+        minWidth=500, minHeight=400, title="Anki", copyBtn=False):
     if not parent:
         parent = aqt.mw.app.activeWindow() or aqt.mw
     diag = QDialog(parent)
@@ -66,6 +66,12 @@ def showText(txt, parent=None, type="text", run=True, geomKey=None, \
     layout.addWidget(text)
     box = QDialogButtonBox(QDialogButtonBox.Close)
     layout.addWidget(box)
+    if copyBtn:
+        def onCopy():
+            QApplication.clipboard().setText(text.toPlainText())
+        btn = QPushButton(_("Copy to Clipboard"))
+        btn.clicked.connect(onCopy)
+        box.addButton(btn, QDialogButtonBox.ActionRole)
     def onReject():
         if geomKey:
             saveGeom(diag, geomKey)


### PR DESCRIPTION
A few changes which I hope will improve the quality of bug reports:

- Add a simple button to copy error messages to the clipboard. I often see users posting incomplete tracebacks, so this might help.
- Try to identify potential add-on culprits and list them in the debug info section. This could be especially helpful now that we use add-on IDs for package names.