### PR TITLE
Simplify installing add-ons from local files

### DIFF
--- a/aqt/addons.py
+++ b/aqt/addons.py
@@ -476,9 +476,9 @@ class AddonsDialog(QDialog):
                                "\n" + "\n".join(names)):
                 log, errs = self.mgr.downloadIds(updated)
                 if log:
-                    tooltip("\n".join(log), parent=self)
+                    tooltip("<br>".join(log), parent=self)
                 if errs:
-                    showWarning("\n".join(errs), parent=self)
+                    showWarning("<br><br>".join(errs), parent=self)
 
                 self.redrawAddons()
 
@@ -534,9 +534,9 @@ class GetAddons(QDialog):
         log, errs = self.mgr.downloadIds(ids)
 
         if log:
-            tooltip("\n".join(log), parent=self.addonsDlg)
+            tooltip("<br>".join(log), parent=self.addonsDlg)
         if errs:
-            showWarning("\n".join(errs))
+            showWarning("<br><br>".join(errs))
 
         self.addonsDlg.redrawAddons()
         QDialog.accept(self)

--- a/aqt/addons.py
+++ b/aqt/addons.py
@@ -21,6 +21,8 @@ from anki.sync import AnkiRequestsClient
 
 class AddonManager:
 
+    ext = ".ankiaddon"
+
     def __init__(self, mw):
         self.mw = mw
         self.dirty = False
@@ -168,7 +170,7 @@ When loading '%(name)s':
     # Processing local add-on files
     ######################################################################
     
-    def processAPKX(self, paths):
+    def processPackages(self, paths):
         log = []
         errs = []
         self.mw.progress.start(immediate=True)
@@ -357,7 +359,8 @@ class AddonsDialog(QDialog):
         if not mime.hasUrls():
             return None
         urls = mime.urls()
-        if all(url.toLocalFile().endswith(".apkx") for url in urls):
+        ext = self.mgr.ext
+        if all(url.toLocalFile().endswith(ext) for url in urls):
             event.acceptProposedAction()
 
     def dropEvent(self, event):
@@ -450,13 +453,13 @@ class AddonsDialog(QDialog):
 
     def onInstallFiles(self, paths=None):
         if not paths:
-            key = (_("Packaged Anki Add-on") + " (*.apkx)")
+            key = (_("Packaged Anki Add-on") + " (*{})".format(self.mgr.ext))
             paths = getFile(self, _("Install Add-on(s)"), None, key,
                             key="addons", multi=True)
             if not paths:
                 return False
         
-        log, errs = self.mgr.processAPKX(paths)
+        log, errs = self.mgr.processPackages(paths)
 
         if log:
             tooltip("<br>".join(log), parent=self)

--- a/aqt/addons.py
+++ b/aqt/addons.py
@@ -348,8 +348,26 @@ class AddonsDialog(QDialog):
         f.delete_2.clicked.connect(self.onDelete)
         f.config.clicked.connect(self.onConfig)
         self.form.addonList.currentRowChanged.connect(self._onAddonItemSelected)
+        self.setAcceptDrops(True)
         self.redrawAddons()
         self.show()
+
+    def dragEnterEvent(self, event):
+        mime = event.mimeData()
+        if not mime.hasUrls():
+            return None
+        urls = mime.urls()
+        if all(url.toLocalFile().endswith(".apkx") for url in urls):
+            event.acceptProposedAction()
+
+    def dropEvent(self, event):
+        mime = event.mimeData()
+        paths = []
+        for url in mime.urls():
+            path = url.toLocalFile()
+            if os.path.exists(path):
+                paths.append(path)
+        self.onInstallFiles(paths)
 
     def redrawAddons(self):
         self.addons = [(self.annotatedName(d), d) for d in self.mgr.allAddons()]

--- a/aqt/utils.py
+++ b/aqt/utils.py
@@ -239,7 +239,7 @@ def getTag(parent, deck, question, tags="user", **kwargs):
 # File handling
 ######################################################################
 
-def getFile(parent, title, cb, filter="*.*", dir=None, key=None):
+def getFile(parent, title, cb, filter="*.*", dir=None, key=None, multi=False):
     "Ask the user for a file."
     assert not dir or not key
     if not dir:
@@ -248,20 +248,22 @@ def getFile(parent, title, cb, filter="*.*", dir=None, key=None):
     else:
         dirkey = None
     d = QFileDialog(parent)
-    d.setFileMode(QFileDialog.ExistingFile)
+    mode = QFileDialog.ExistingFiles if multi else QFileDialog.ExistingFile
+    d.setFileMode(mode)
     if os.path.exists(dir):
         d.setDirectory(dir)
     d.setWindowTitle(title)
     d.setNameFilter(filter)
     ret = []
     def accept():
-        file = str(list(d.selectedFiles())[0])
+        files = list(d.selectedFiles())
         if dirkey:
-            dir = os.path.dirname(file)
+            dir = os.path.dirname(files[0])
             aqt.mw.pm.profile[dirkey] = dir
+        result = files if multi else files[0]
         if cb:
-            cb(file)
-        ret.append(file)
+            cb(result)
+        ret.append(result)
     d.accepted.connect(accept)
     if key:
         restoreState(d, key)

--- a/designer/addons.ui
+++ b/designer/addons.ui
@@ -48,6 +48,13 @@
       </widget>
      </item>
      <item>
+      <widget class="QPushButton" name="installFromFile">
+       <property name="text">
+        <string>Install from file...</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="checkForUpdates">
        <property name="text">
         <string>Check for Updates</string>


### PR DESCRIPTION
Introduces the ability to conveniently install add-ons from local add-on archives, doing away with a lot of the common pitfalls when distributing add-ons outside of AnkiWeb.

### Background

Installing add-ons from AnkiWeb is as easy at it can be. However, some scenarios like running beta tests, sharing private builds, or distributing extensions to existing add-ons still require users to install add-ons manually. This process is fraught with pitfalls such as users downloading the wrong archive, unpacking it incorrectly, or moving the add-on files to the wrong location. This PR seeks to address these issues by introducing a new file type for distributing Anki add-ons and extending the add-on UI with a number of convenience features for handling these files.

### APKX File Specification

#### Overview

APKX files are just a ZIP archive of the add-on with a manifest file contained within. The manifest follows JSON notation and allows add-on authors to define properties such as the add-on's name, modification date, and the destination package the add-on should be unpacked to.

In its current implementation the manifest file recognizes the following keys:

- `name` (`str`) [required]: Display name of the add-on (e.g. `Review Heatmap`)
- `package` (`str`) [required]: Package name of the add-on, i.e. the subfolder within Anki's `addons21` folder the archive should be unpacked to (e.g. `review_heatmap` or `1771074083`)
- `mod` (`int`) [optional]: Modification/creation time of the package as a unix timestamp (similar to AnkiWeb and in lieu of a canonical versioning scheme)

This schema could be easily extended in the future if the need arises.

#### Reasoning

*Why the need for a manifest?*

Without a manifest we are stuck with using file names to determine the add-on's metadata, which – as you might imagine – is not a great option.

Manifests seem to be the industry standard for similar extension systems, e.g. Chrome extensions, Firefox plugins, and VS Code extensions.

*Why not use the existing meta.json file for supplying metadata?*

`meta.json` primarily keeps track of add-on installation and configuration state. Mixing in static package metadata didn't seem like a good idea.

*Why use a custom file format rather than ZIP files?*

I explored using ZIP files in an initial, unpublished version of this PR, but quickly arrived at the conclusion that this would be a misstep. My main concern with ZIP files is that users will not be able to easily identify what does and doesn't constitute a valid add-on archive. For instance, I'd imagine that ZIP file support would encourage users to try to install add-ons from GitHub repo archives, etc.

By opting for a custom file format I felt that we could eliminate an entire class of potential bug reports. I mean, there must be a reason why Chrome/ium uses `.crx`, Firefox `.xpi`, and VS Code `.vsix`.

*Why "APKX" ?*

Well, I couldn't think of anything better. I guess it plays into that trope of using `x` in some way to identify extensions, as demonstrated by the file types mentioned above. However, I'm totally open to suggestions.

*Why make the `mod` manifest key optional?*

One of the use cases I envision APKX files covering is providing optional extensions to existing add-ons. These could be things like additional themes, language-specific dictionaries, etc. In cases like this you would want to copy additional files to a specific add-on directory without necessarily changing the modification date stored by Anki (as that might impede further updates from AnkiWeb).


### UI Implementation

This PR currently extends Anki's UI with the following new features:

- A new button in the add-on manager that allows users to select one or more APKX files to install
- The ability to drag and drop APKX files onto the add-on manager to quickly install them

Both of these UX flows provide ample feedback on the installation process, notifying users of any errors that might arise.

Here is a quick demo that showcases all of this in action:

![screencast_20190218_073236](https://user-images.githubusercontent.com/5459332/52936026-4c7fdf80-335b-11e9-9695-b3351dd8f6e4.gif)

----

### Discussion

As this PR introduces a number of significant changes to Anki's add-on system, I thought it would be best to discuss these in as broad a forum as possible. I hope it's OK if I ping some people in the add-on dev community here. In no particular order (and sorry in advance if I left anyone out!):

@Arthur-Milchior @cayennes @eshapard @FooSoft @hssm @krassowski @lovac42 @luoliyan @ospalh @phu54321 @simgunz @sth2018 @upday7

Your feedback would be very much appreciated! Please feel to use this [sample apkx](https://glutanimate.com/files/sample_addon.apkx) if you would like to give these changes a try yourself.