### PR TITLE
Correct a bug during add-on update

### DIFF
--- a/aqt/addons.py
+++ b/aqt/addons.py
@@ -196,7 +196,7 @@ When loading '%(name)s':
         updated = []
         for dir, ts in mods:
             sid = str(dir)
-            if self.addonMeta(sid).get("mod") < ts:
+            if self.addonMeta(sid).get("mod",0) < ts:
                 updated.append(sid)
         return updated
 


### PR DESCRIPTION
If an add-on folder contains only number, but does not contains a
meta.json file, or if this file does not contains a "mod" value, then
the following uninformative message error occur:
```Python
  File "aqt/addons.py", line 387, in onCheckForUpdates
  File "aqt/addons.py", line 183, in checkForUpdates
  File "aqt/addons.py", line 199, in _updatedIds
<class 'TypeError'>: '<' not supported between instances of 'NoneType' and 'int'
```

This is because there is a .get in a code while the None value makes
no sens. Thus, I replaced None by a 0 value. Which ensure that, if the
last modification time is missing, the update will be done. Three case
may occur:
* either the addon is already up to date, and it's only a waste of
  bandwidth
* either the add-on is not up to date, and updating was the initial
  goal anyway
* Or some change did occur in the add-on folder (which is actually
  probably, since it would explain the "missing mod problem"; in this
  case this change may be lost, but thout would be the same problem
  if the mod number was still there.

Other solutions which I could implement would be:
* asking for the user whether they want to update
* considering that it's not an ankiweb related add-on anymore, and
  ignore it.