### PR TITLE
Further tweaks to the add-on manager and config editor UI

### DIFF
--- a/aqt/addons.py
+++ b/aqt/addons.py
@@ -458,15 +458,15 @@ class AddonsDialog(QDialog):
         
         self.addons = [(self.annotatedName(d), d) for d in mgr.allAddons()]
         self.addons.sort()
-        
+
+        selected = set(self.selectedAddons())
         addonList.clear()
         for name, dir in self.addons:
             item = QListWidgetItem(name, addonList)
             if not mgr.isEnabled(dir):
                 item.setForeground(Qt.gray)
-
-        if self.addons:
-            addonList.setCurrentRow(0)
+            if dir in selected:
+                item.setSelected(True)
 
         addonList.repaint()
 

--- a/aqt/addons.py
+++ b/aqt/addons.py
@@ -648,6 +648,7 @@ class ConfigEditor(QDialog):
     def onRestoreDefaults(self):
         default_conf = self.mgr.addonConfigDefaults(self.addon)
         self.updateText(default_conf)
+        tooltip(_("Restored defaults"), parent=self)
 
     def setupFonts(self):
         font_mono = QFontDatabase.systemFont(QFontDatabase.FixedFont)

--- a/aqt/addons.py
+++ b/aqt/addons.py
@@ -11,7 +11,8 @@ from send2trash import send2trash
 
 from aqt.qt import *
 from aqt.utils import showInfo, openFolder, isWin, openLink, \
-    askUser, restoreGeom, saveGeom, showWarning, tooltip, getFile
+    askUser, restoreGeom, saveGeom, restoreSplitter, saveSplitter, \
+    showWarning, tooltip, getFile
 from zipfile import ZipFile
 import aqt.forms
 import aqt
@@ -640,6 +641,8 @@ class ConfigEditor(QDialog):
         self.setupFonts()
         self.updateHelp()
         self.updateText(self.conf)
+        restoreGeom(self, "addonconf")
+        restoreSplitter(self.form.splitter, "addonconf")
         self.show()
 
     def onRestoreDefaults(self):
@@ -648,6 +651,7 @@ class ConfigEditor(QDialog):
 
     def setupFonts(self):
         font_mono = QFontDatabase.systemFont(QFontDatabase.FixedFont)
+        font_mono.setPointSize(font_mono.pointSize() + 1)
         self.form.editor.setFont(font_mono)
 
     def updateHelp(self):
@@ -661,6 +665,14 @@ class ConfigEditor(QDialog):
         self.form.editor.setPlainText(
             json.dumps(conf, ensure_ascii=False, sort_keys=True,
                        indent=4, separators=(',', ': ')))
+
+    def onClose(self):
+        saveGeom(self, "addonconf")
+        saveSplitter(self.form.splitter, "addonconf")
+
+    def reject(self):
+        self.onClose()
+        super().reject()
 
     def accept(self):
         txt = self.form.editor.toPlainText()
@@ -680,5 +692,6 @@ class ConfigEditor(QDialog):
             act = self.mgr.configUpdatedAction(self.addon)
             if act:
                 act(new_conf)
-
+        
+        self.onClose()
         super().accept()

--- a/aqt/addons.py
+++ b/aqt/addons.py
@@ -476,9 +476,9 @@ class AddonsDialog(QDialog):
                                "\n" + "\n".join(names)):
                 log, errs = self.mgr.downloadIds(updated)
                 if log:
-                    tooltip("\n".join(log), parent=self)
+                    tooltip("<br>".join(log), parent=self)
                 if errs:
-                    showWarning("\n".join(errs), parent=self)
+                    showWarning("<br><br>".join(errs), parent=self)
 
                 self.redrawAddons()
 
@@ -534,9 +534,9 @@ class GetAddons(QDialog):
         log, errs = self.mgr.downloadIds(ids)
 
         if log:
-            tooltip("\n".join(log), parent=self.addonsDlg)
+            tooltip("<br>".join(log), parent=self.addonsDlg)
         if errs:
-            showWarning("\n".join(errs))
+            showWarning("<br><br>".join(errs))
 
         self.addonsDlg.redrawAddons()
         QDialog.accept(self)

--- a/aqt/addons.py
+++ b/aqt/addons.py
@@ -21,6 +21,8 @@ from anki.sync import AnkiRequestsClient
 
 class AddonManager:
 
+    ext = ".ankiaddon"
+
     def __init__(self, mw):
         self.mw = mw
         self.dirty = False
@@ -168,7 +170,7 @@ When loading '%(name)s':
     # Processing local add-on files
     ######################################################################
     
-    def processAPKX(self, paths):
+    def processPackages(self, paths):
         log = []
         errs = []
         self.mw.progress.start(immediate=True)
@@ -357,7 +359,8 @@ class AddonsDialog(QDialog):
         if not mime.hasUrls():
             return None
         urls = mime.urls()
-        if all(url.toLocalFile().endswith(".apkx") for url in urls):
+        ext = self.mgr.ext
+        if all(url.toLocalFile().endswith(ext) for url in urls):
             event.acceptProposedAction()
 
     def dropEvent(self, event):
@@ -450,13 +453,13 @@ class AddonsDialog(QDialog):
 
     def onInstallFiles(self, paths=None):
         if not paths:
-            key = (_("Packaged Anki Add-on") + " (*.apkx)")
+            key = (_("Packaged Anki Add-on") + " (*{})".format(self.mgr.ext))
             paths = getFile(self, _("Install Add-on(s)"), None, key,
                             key="addons", multi=True)
             if not paths:
                 return False
         
-        log, errs = self.mgr.processAPKX(paths)
+        log, errs = self.mgr.processPackages(paths)
 
         if log:
             tooltip("<br>".join(log), parent=self)

--- a/aqt/addons.py
+++ b/aqt/addons.py
@@ -453,14 +453,22 @@ class AddonsDialog(QDialog):
         return QDialog.reject(self)
 
     def redrawAddons(self):
-        self.addons = [(self.annotatedName(d), d) for d in self.mgr.allAddons()]
+        addonList = self.form.addonList
+        mgr = self.mgr
+        
+        self.addons = [(self.annotatedName(d), d) for d in mgr.allAddons()]
         self.addons.sort()
-        self.form.addonList.clear()
-        self.form.addonList.addItems([r[0] for r in self.addons])
-        if self.addons:
-            self.form.addonList.setCurrentRow(0)
+        
+        addonList.clear()
+        for name, dir in self.addons:
+            item = QListWidgetItem(name, addonList)
+            if not mgr.isEnabled(dir):
+                item.setForeground(Qt.gray)
 
-        self.form.addonList.repaint()
+        if self.addons:
+            addonList.setCurrentRow(0)
+
+        addonList.repaint()
 
     def _onAddonItemSelected(self, row_int):
         try:
@@ -470,9 +478,8 @@ class AddonsDialog(QDialog):
         self.form.viewPage.setEnabled(bool (re.match(r"^\d+$", addon)))
 
     def annotatedName(self, dir):
-        meta = self.mgr.addonMeta(dir)
         buf = self.mgr.addonName(dir)
-        if meta.get('disabled'):
+        if not self.mgr.isEnabled(dir):
             buf += _(" (disabled)")
         return buf
 

--- a/aqt/addons.py
+++ b/aqt/addons.py
@@ -348,8 +348,26 @@ class AddonsDialog(QDialog):
         f.delete_2.clicked.connect(self.onDelete)
         f.config.clicked.connect(self.onConfig)
         self.form.addonList.currentRowChanged.connect(self._onAddonItemSelected)
+        self.setAcceptDrops(True)
         self.redrawAddons()
         self.show()
+
+    def dragEnterEvent(self, event):
+        mime = event.mimeData()
+        if not mime.hasUrls():
+            return None
+        urls = mime.urls()
+        if all(url.toLocalFile().endswith(".apkx") for url in urls):
+            event.acceptProposedAction()
+
+    def dropEvent(self, event):
+        mime = event.mimeData()
+        paths = []
+        for url in mime.urls():
+            path = url.toLocalFile()
+            if os.path.exists(path):
+                paths.append(path)
+        self.onInstallFiles(paths)
 
     def redrawAddons(self):
         self.addons = [(self.annotatedName(d), d) for d in self.mgr.allAddons()]

--- a/aqt/utils.py
+++ b/aqt/utils.py
@@ -239,7 +239,7 @@ def getTag(parent, deck, question, tags="user", **kwargs):
 # File handling
 ######################################################################
 
-def getFile(parent, title, cb, filter="*.*", dir=None, key=None):
+def getFile(parent, title, cb, filter="*.*", dir=None, key=None, multi=False):
     "Ask the user for a file."
     assert not dir or not key
     if not dir:
@@ -248,20 +248,22 @@ def getFile(parent, title, cb, filter="*.*", dir=None, key=None):
     else:
         dirkey = None
     d = QFileDialog(parent)
-    d.setFileMode(QFileDialog.ExistingFile)
+    mode = QFileDialog.ExistingFiles if multi else QFileDialog.ExistingFile
+    d.setFileMode(mode)
     if os.path.exists(dir):
         d.setDirectory(dir)
     d.setWindowTitle(title)
     d.setNameFilter(filter)
     ret = []
     def accept():
-        file = str(list(d.selectedFiles())[0])
+        files = list(d.selectedFiles())
         if dirkey:
-            dir = os.path.dirname(file)
+            dir = os.path.dirname(files[0])
             aqt.mw.pm.profile[dirkey] = dir
+        result = files if multi else files[0]
         if cb:
-            cb(file)
-        ret.append(file)
+            cb(result)
+        ret.append(result)
     d.accepted.connect(accept)
     if key:
         restoreState(d, key)

--- a/designer/addonconf.ui
+++ b/designer/addonconf.ui
@@ -57,7 +57,7 @@
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_2">
         <property name="leftMargin">
-         <number>4</number>
+         <number>6</number>
         </property>
         <property name="topMargin">
          <number>0</number>

--- a/designer/addons.ui
+++ b/designer/addons.ui
@@ -48,6 +48,13 @@
       </widget>
      </item>
      <item>
+      <widget class="QPushButton" name="installFromFile">
+       <property name="text">
+        <string>Install from file...</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="checkForUpdates">
        <property name="text">
         <string>Check for Updates</string>

--- a/designer/addons.ui
+++ b/designer/addons.ui
@@ -32,7 +32,7 @@
      <item>
       <widget class="QListWidget" name="addonList">
        <property name="selectionMode">
-        <enum>QAbstractItemView::ContiguousSelection</enum>
+        <enum>QAbstractItemView::ExtendedSelection</enum>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Config editor:

  * Store geometry and splitter arrangement.
  * Slightly increase editor font size and help area margin
  * Provide tooltip feedback on restoring defaults

Add-on manager:

  * Switch to non-contiguous multi-selection in add-on list to allow for freely ctrl-selecting items across the entire length
  * Color disabled add-ons gray and preseve selected items on redraw (cf. https://anki.tenderapp.com/discussions/beta-testing/1390 and https://anki.tenderapp.com/discussions/ankidesktop/32744)

I wasn't sure whether to wait on #283 before submitting these or not. This branch is based on that PR, so the changes should hopefully fast-forward on merge if the other PR is merged beforehand. Hope this is OK. If not please let me know and I'll make sure to wait in cases like this in the future.

(I mostly thought I should submit these now because I wanted to prevent any kind of duplicate efforts. Some of the changes listed above seemed to have been brought up quite frequently recently, so I figured you might have gotten on to this, otherwise.)