### PR TITLE
Add a button to copy debug info to the About screen

### DIFF
--- a/aqt/about.py
+++ b/aqt/about.py
@@ -4,7 +4,7 @@
 
 from aqt.qt import *
 import aqt.forms
-from aqt.utils import versionWithBuild
+from aqt.utils import versionWithBuild, supportText, tooltip
 
 class ClosableQDialog(QDialog):
     def reject(self):
@@ -24,6 +24,23 @@ def show(mw):
     mw.setupDialogGC(dialog)
     abt = aqt.forms.about.Ui_About()
     abt.setupUi(dialog)
+
+    # Copy debug info
+    ######################################################################
+    def onCopy():
+        addmgr = mw.addonManager
+        addons = "\n".join(addmgr.annotatedName(d) for d in addmgr.allAddons())
+        info = "\n".join((supportText(), "Add-ons:\n\n{}".format(addons)))
+        QApplication.clipboard().setText(info)
+        tooltip(_("Copied to clipboard"), parent=dialog)
+
+    btn = QPushButton(_("Copy Debug Info"))
+    btn.clicked.connect(onCopy)
+    abt.buttonBox.addButton(btn, QDialogButtonBox.ActionRole)
+    abt.buttonBox.button(QDialogButtonBox.Ok).setFocus()
+
+    # WebView contents
+    ######################################################################
     abouttext = "<center><img src='/_anki/imgs/anki-logo-thin.png'></center>"
     abouttext += '<p>' + _("Anki is a friendly, intelligent spaced learning \
 system. It's free and open source.")

--- a/aqt/addons.py
+++ b/aqt/addons.py
@@ -115,6 +115,12 @@ When loading '%(name)s':
     def addonName(self, dir):
         return self.addonMeta(dir).get("name", dir)
 
+    def annotatedName(self, dir):
+        buf = self.addonName(dir)
+        if not self.isEnabled(dir):
+            buf += _(" (disabled)")
+        return buf
+
     # Conflict resolution
     ######################################################################
 
@@ -456,7 +462,7 @@ class AddonsDialog(QDialog):
         addonList = self.form.addonList
         mgr = self.mgr
         
-        self.addons = [(self.annotatedName(d), d) for d in mgr.allAddons()]
+        self.addons = [(mgr.annotatedName(d), d) for d in mgr.allAddons()]
         self.addons.sort()
 
         selected = set(self.selectedAddons())
@@ -476,12 +482,6 @@ class AddonsDialog(QDialog):
         except IndexError:
             addon = ''
         self.form.viewPage.setEnabled(bool (re.match(r"^\d+$", addon)))
-
-    def annotatedName(self, dir):
-        buf = self.mgr.addonName(dir)
-        if not self.mgr.isEnabled(dir):
-            buf += _(" (disabled)")
-        return buf
 
     def selectedAddons(self):
         idxs = [x.row() for x in self.form.addonList.selectedIndexes()]

--- a/aqt/errors.py
+++ b/aqt/errors.py
@@ -7,7 +7,7 @@ import re
 
 from anki.lang import _
 from aqt.qt import *
-from aqt.utils import showText, showWarning
+from aqt.utils import showText, showWarning, supportText
 from aqt import mw
 
 if not os.environ.get("DEBUG"):
@@ -126,10 +126,10 @@ add-ons section</a> of our support site.
 """)        
         if self.mw.addonManager.dirty:
             txt = pluginText
-            error = self._supportText() + self._addonText(error) + "\n" + error
+            error = supportText() + self._addonText(error) + "\n" + error
         else:
             txt = stdText
-            error = self._supportText() + "\n" + error
+            error = supportText() + "\n" + error
         
         # show dialog
         txt = txt + "<div style='white-space: pre-wrap'>" + error + "</div>"
@@ -146,27 +146,3 @@ add-ons section</a> of our support site.
         # highlight importance of first add-on:
         addons[0] = "<b>{}</b>".format(addons[0])
         return txt.format(", ".join(addons))
-
-    def _supportText(self):
-        import platform
-        from aqt.utils import versionWithBuild
-
-        if isWin:
-            platname = "Windows " + platform.win32_ver()[0]
-        elif isMac:
-            platname = "Mac " + platform.mac_ver()[0]
-        else:
-            platname = "Linux"
-
-        def schedVer():
-            try:
-                return self.mw.col.schedVer()
-            except:
-                return "?"
-
-        return """\
-Anki {} Python {} Qt {} PyQt {}
-Platform: {}
-Flags: frz={} ao={} sv={}
-""".format(versionWithBuild(), platform.python_version(), QT_VERSION_STR, PYQT_VERSION_STR, platname,
-           getattr(sys, "frozen", False), self.mw.addonManager.dirty, schedVer())

--- a/aqt/utils.py
+++ b/aqt/utils.py
@@ -567,6 +567,33 @@ def versionWithBuild():
         build = "dev"
     return "%s (%s)" % (appVersion, build)
 
+def supportText():
+    import platform
+    from aqt import mw
+    from aqt.utils import versionWithBuild
+
+    if isWin:
+        platname = "Windows " + platform.win32_ver()[0]
+    elif isMac:
+        platname = "Mac " + platform.mac_ver()[0]
+    else:
+        platname = "Linux"
+
+    def schedVer():
+        try:
+            return mw.col.schedVer()
+        except:
+            return "?"
+
+    return """\
+Anki {} Python {} Qt {} PyQt {}
+Platform: {}
+Flags: frz={} ao={} sv={}
+""".format(versionWithBuild(), platform.python_version(),
+           QT_VERSION_STR, PYQT_VERSION_STR, platname,
+           getattr(sys, "frozen", False),
+           mw.addonManager.dirty, schedVer())
+
 ######################################################################
 
 # adapted from version detection in qutebrowser


### PR DESCRIPTION
When dealing with issues that don't produce concrete error messages, it can sometimes be difficult to reliably gather all of the necessary information to get to the bottom of things. This is especially true for add-on authors. The commits in this PR introduce a button to the About screen that conveniently copies the following information to the clipboard:

- support info otherwise shown in error dialogs (platform, anki version, toolkit versions, flags, etc.)
- a list of all the add-ons installed by the user and their state

Together these should hopefully serve as a solid starting point for any bug-hunting adventure.

(I had to shift two methods around in the errors and addons modules to prevent code duplication. I hope that's OK.)