### PR TITLE
Fix subpixel font anti-aliasing

### DIFF
--- a/aqt/webview.py
+++ b/aqt/webview.py
@@ -18,7 +18,6 @@ class AnkiWebPage(QWebEnginePage):
         QWebEnginePage.__init__(self)
         self._onBridgeCmd = onBridgeCmd
         self._setupBridge()
-        self.setBackgroundColor(Qt.transparent)
 
     def _setupBridge(self):
         class Bridge(QObject):
@@ -93,6 +92,7 @@ class AnkiWebView(QWebEngineView):
         QWebEngineView.__init__(self, parent=parent)
         self.title = "default"
         self._page = AnkiWebPage(self._onBridgeCmd)
+        self._page.setBackgroundColor(self._getWindowColor())  # reduce flicker
 
         self._domDone = True
         self._pendingActions = []
@@ -216,6 +216,12 @@ class AnkiWebView(QWebEngineView):
         else:
             return 3
 
+    def _getWindowColor(self):
+        if isMac:
+            # standard palette does not return correct window color on macOS
+            return QColor("#ececec")
+        return self.style().standardPalette().color(QPalette.Window)
+
     def stdHtml(self, body, css=[], js=["jquery.js"], head=""):
         if isWin:
             widgetspec = "button { font-size: 12px; font-family:'Segoe UI'; }"
@@ -263,7 +269,7 @@ div[contenteditable="true"]:focus {
 <title>{}</title>
 
 <style>
-body {{ zoom: {}; {} }}
+body {{ zoom: {}; background: {}; {} }}
 {}
 </style>
   
@@ -271,7 +277,8 @@ body {{ zoom: {}; {} }}
 </head>
 
 <body>{}</body>
-</html>""".format(self.title, self.zoomFactor(), fontspec, widgetspec, head, body)
+</html>""".format(self.title, self.zoomFactor(), self._getWindowColor().name(),
+                  fontspec, widgetspec, head, body)
         #print(html)
         self.setHtml(html)
 


### PR DESCRIPTION
Two years ago, 59f877737e6e0cc23da056f02bc2d269e860d13d introduced `Qt.transparent` as the default background color for webviews. The intent was to reduce the flicker experienced during web view load time. Setting the color to transparent also had the benefit of allowing web views to conform with the platform default widget color.

However, it seems like transparent backgrounds prevent subpixel font anti-aliasing from working correctly. This is best exemplified by the screenshots in the description of the [Text Rendering Fix add-on](https://ankiweb.net/shared/info/94394764), which first drew attention to this issue:

Transparent background
![](https://i.imgur.com/vLjWYWG.png)

Regular background
![](https://i.imgur.com/UmIBRsk.png)

This commit fixes subpixel anti-aliasing by switching from `Qt.transparent` to the platform default window background. From my tests so far this improves font rendering on non-retina displays across all platforms, while not affecting the app theme or flicker prevention in any way.

Edit: Please note that the add-on hardcodes a background color, which is why the colors in the screenshot above differ. The changes in this PR use a different approach which should result in no bg change.