### PR TITLE
Extend mediasrv to also serve media files in addons directory

### DIFF
--- a/aqt/addons.py
+++ b/aqt/addons.py
@@ -408,6 +408,19 @@ Are you sure you want to continue?"""
         if not os.path.exists(bp):
             return
         os.rename(bp, p)
+    
+    # Web Exports
+    ######################################################################
+
+    _webExports = {}
+
+    def setWebExports(self, module, pattern):
+        addon = self.addonFromModule(module)
+        self._webExports[addon] = pattern
+    
+    def getWebExports(self, addon):
+        return self._webExports.get(addon)
+
 
 # Add-ons Dialog
 ######################################################################

--- a/aqt/main.py
+++ b/aqt/main.py
@@ -1350,7 +1350,8 @@ Please ensure a profile is open and Anki is not busy, then try again."""),
     ##########################################################################
 
     def setupMediaServer(self):
-        self.mediaServer = aqt.mediasrv.MediaServer()
+        self.mediaServer = aqt.mediasrv.MediaServer(
+            addonFolder=self.pm.addonFolder())
         self.mediaServer.start()
 
     def baseHTML(self):

--- a/aqt/main.py
+++ b/aqt/main.py
@@ -1350,8 +1350,7 @@ Please ensure a profile is open and Anki is not busy, then try again."""),
     ##########################################################################
 
     def setupMediaServer(self):
-        self.mediaServer = aqt.mediasrv.MediaServer(
-            addonFolder=self.pm.addonFolder())
+        self.mediaServer = aqt.mediasrv.MediaServer(self)
         self.mediaServer.start()
 
     def baseHTML(self):

--- a/aqt/mediasrv.py
+++ b/aqt/mediasrv.py
@@ -156,7 +156,7 @@ class RequestHandler(http.server.SimpleHTTPRequestHandler):
             if not pattern:
                 return path
             
-            if not re.match("^{}$".format(pattern), subPath):
+            if not re.fullmatch(pattern, subPath):
                 return path
             
             newPath = os.path.join(addMgr.addonsFolder(), addonPath)


### PR DESCRIPTION
Because of the updated security policies introduced with the switch to QWebEngine, it is no longer possible to easily reference media files, scripts, and stylesheets that are packaged with add-ons.

The changes proposed in this PR update Anki's media server to rewrite references starting with `/_addons` to the addons directory, making it easier for add-on devs to extend Anki's web views with their own content.

Here's a quick proof-of-concept exemplifying how an add-on could add an image to Anki's deck browser with this change implemented:

```python
from aqt import mw
from aqt.deckbrowser import DeckBrowser
from anki.hooks import wrap

def deckbrowserRenderStats(self, _old):
    addon = mw.addonManager.addonFromModule(__name__)
    add = """<br><img src='/_addons/{}/test.png'>""".format(addon)
    return _old(self) + add

DeckBrowser._renderStats = wrap(
    DeckBrowser._renderStats, deckbrowserRenderStats, "around")
```