### PR TITLE
Fix permissions error on Windows

### DIFF
--- a/anki/sound.py
+++ b/anki/sound.py
@@ -149,16 +149,20 @@ def cleanupOldMplayerProcesses():
 
     exeDir = os.path.dirname(os.path.abspath(sys.argv[0]))
 
-    for proc in psutil.process_iter(attrs=['pid', 'name', 'exe']):
-        if not proc.info['exe'] or proc.info['name'] != 'mplayer.exe':
-            continue
+    for proc in psutil.process_iter():
+        try:
+            info = proc.as_dict(attrs=['pid', 'name', 'exe'])
+            if not info['exe'] or info['name'] != 'mplayer.exe':
+                continue
 
-        # not anki's bundled mplayer
-        if os.path.dirname(proc.info['exe']) != exeDir:
-            continue
+            # not anki's bundled mplayer
+            if os.path.dirname(info['exe']) != exeDir:
+                continue
 
-        print("terminating old mplayer process...")
-        proc.kill()
+            print("terminating old mplayer process...")
+            proc.kill()
+        except SystemError:
+            pass
 
 mplayerCmd = ["mplayer", "-really-quiet", "-noautosub"]
 if isWin:


### PR DESCRIPTION
Exceptions are raised by some processes in `cleanupOldMplayerProcesses()` on Windows:

```
Traceback (most recent call last):
  File "C:\Python37\lib\site-packages\psutil\_pswindows.py", line 639, in wrapper
    return fun(self, *args, **kwargs)
  File "C:\Python37\lib\site-packages\psutil\_pswindows.py", line 705, in exe
    exe = cext.proc_exe(self.pid)
PermissionError: [WinError 5] Åtkomst nekad

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Python37\lib\site-packages\psutil\__init__.py", line 751, in exe
    exe = self._proc.exe()
  File "C:\Python37\lib\site-packages\psutil\_pswindows.py", line 642, in wrapper
    raise AccessDenied(self.pid, self._name)
psutil.AccessDenied: psutil.AccessDenied (pid=96, name='Registry')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Python37\lib\site-packages\psutil\_pswindows.py", line 712, in cmdline
    ret = cext.proc_cmdline(self.pid, use_peb=True)
PermissionError: [WinError 5] Åtkomst nekad

During handling of the above exception, another exception occurred:

PermissionError: [WinError 5] Åtkomst nekad

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "runanki", line 3, in <module>
    import aqt
  File "C:\Users\David\Documents\dev\anki\aqt\__init__.py", line 4, in <module>
    from anki import version as _version
  File "C:\Users\David\Documents\dev\anki\anki\__init__.py", line 14, in <module>
    from anki.storage import Collection
  File "C:\Users\David\Documents\dev\anki\anki\storage.py", line 11, in <module>
    from anki.collection import _Collection
  File "C:\Users\David\Documents\dev\anki\anki\collection.py", line 25, in <module>
    from anki.sound import stripSounds
  File "C:\Users\David\Documents\dev\anki\anki\sound.py", line 181, in <module>
    cleanupOldMplayerProcesses()
  File "C:\Users\David\Documents\dev\anki\anki\sound.py", line 152, in cleanupOldMplayerProcesses
    for proc in psutil.process_iter(attrs=['pid', 'name', 'exe']):
  File "C:\Python37\lib\site-packages\psutil\__init__.py", line 1539, in process_iter
    yield add(pid)
  File "C:\Python37\lib\site-packages\psutil\__init__.py", line 1521, in add
    proc.info = proc.as_dict(attrs=attrs, ad_value=ad_value)
  File "C:\Python37\lib\site-packages\psutil\__init__.py", line 630, in as_dict
    ret = meth()
  File "C:\Python37\lib\site-packages\psutil\__init__.py", line 753, in exe
    return guess_it(fallback=err)
  File "C:\Python37\lib\site-packages\psutil\__init__.py", line 735, in guess_it
    cmdline = self.cmdline()
  File "C:\Python37\lib\site-packages\psutil\__init__.py", line 768, in cmdline
    return self._proc.cmdline()
  File "C:\Python37\lib\site-packages\psutil\_pswindows.py", line 639, in wrapper
    return fun(self, *args, **kwargs)
  File "C:\Python37\lib\site-packages\psutil\_pswindows.py", line 715, in cmdline
    ret = cext.proc_cmdline(self.pid, use_peb=False)
SystemError: <class 'OSError'> returned a result with an error set
```

so those processes should probably be skipped