### PR TITLE
Set QTWEBENGINE_DICTIONARIES_PATH to pave the way for spell checking

### DIFF
--- a/aqt/main.py
+++ b/aqt/main.py
@@ -73,6 +73,7 @@ class AnkiQt(QMainWindow):
         self.setupThreads()
         self.setupMediaServer()
         self.setupSound()
+        self.setupSpellCheck()
         self.setupMainWindow()
         self.setupSystemSpecific()
         self.setupStyle()
@@ -636,6 +637,10 @@ title="%s" %s>%s</button>''' % (
         self.addonManager = aqt.addons.AddonManager(self)
         if not self.safeMode:
             self.addonManager.loadAddons()
+
+    def setupSpellCheck(self):
+        os.environ["QTWEBENGINE_DICTIONARIES_PATH"] = (
+            os.path.join(self.pm.base, "dictionaries"))
 
     def setupThreads(self):
         self._mainThread = QThread.currentThread()


### PR DESCRIPTION
Hey Damien,

I'm currently working on an add-on for Anki that will introduce spell checking support to the note editor. Eventually I would love to submit this as a PR. However, because the changes would be rather extensive I would prefer to first run them through some community tests as an add-on.

Unfortunately I did run into somewhat of a wall with setting the spelling dictionary look-up path.

Ever since Qt 5.12 it is now possible to set a custom path for dictionaries through the `QTWEBENGINE_DICTIONARIES_PATH` environment variable. This is what made the spell checking idea viable in the fist place, as with previous Qt releases you would have to use hard-coded Qt data paths (that is: the Anki binary builds would have had to package the dictionary files themselves, which for all locales would amount to ≈100 MB in total).

The issue I'm facing right now is that this env var has to be set before the first web view is initialized, i.e. before setupMainWindow in aqt.main. Since that's outside the reach of add-ons, I'm at an impasse with this.

This PR hopes to address the issue by setting the env var in question right before the main window is initialized. I went with a `dictionaries` subfolder in Anki's config base path since that seemed the most fitting and consistent to me.

The change should have no ill side-effects as it simply sets the environment variable without creating the folder in question. The add-on I'm working on will contain checks for Anki & Qt versions, so that both alternate and standard builds will be properly dealt with.

Browsing through tenderapp and reddit, spell checking did seem like a pretty frequently requested feature, and so I'm very much looking forward to bringing this to the community, and also getting it off your todo list!