### PR TITLE
Making rendering (and requirements) quicker

### DIFF
--- a/anki/template/template.py
+++ b/anki/template/template.py
@@ -73,62 +73,53 @@ class Template:
         tag = r"%(otag)s(#|=|&|!|>|\{)?(.+?)\1?%(ctag)s+"
         self.tag_re = re.compile(tag % tags)
 
+    def sub_section(self, match):
+        section, section_name, inner = match.group(0, 1, 2)
+        section_name = section_name.strip()
+
+        # val will contain the content of the field considered
+        # right now
+        val = None
+        m = re.match("c[qa]:(\d+):(.+)", section_name)
+        if m:
+            # get full field text
+            txt = get_or_attr(context, m.group(2), None)
+            m = re.search(clozeReg%m.group(1), txt)
+            if m:
+                val = m.group(1)
+        else:
+            val = get_or_attr(context, section_name, None)
+        replacer = ''
+        # Whether it's {{^
+        inverted = section[2] == "^"
+        # Ensuring we don't consider whitespace in wval
+        if val:
+            val = stripHTMLMedia(val).strip()
+        if (val and not inverted) or (not val and inverted):
+                replacer = inner
+        return replacer
+
     def render_sections(self, template, context):
         """Expands sections."""
-        while 1:
-            match = self.section_re.search(template)
-            if match is None:
-                break
-
-            section, section_name, inner = match.group(0, 1, 2)
-            section_name = section_name.strip()
-
-            # check for cloze
-            val = None
-            m = re.match(r"c[qa]:(\d+):(.+)", section_name)
-            if m:
-                # get full field text
-                txt = get_or_attr(context, m.group(2), None)
-                m = re.search(clozeReg%m.group(1), txt)
-                if m:
-                    val = m.group(1)
-            else:
-                val = get_or_attr(context, section_name, None)
-
-            replacer = ''
-            inverted = section[2] == "^"
-            if val:
-                val = stripHTMLMedia(val).strip()
-            if (val and not inverted) or (not val and inverted):
-                replacer = inner
-
-            template = template.replace(section, replacer)
-
+        n = 1
+        while n:
+            template, n = self.section_re.subn(self.sub_section, template)
         return template
+
+    def sub_tag(self, match, context):
+        tag, tag_type, tag_name = match.group(0, 1, 2)
+        # i.e. "{{!foo}}", "!", "foo"
+        tag_name = tag_name.strip()
+        func = modifiers[tag_type]
+        replacement = func(self, tag_name, context)
+        return replacement
 
     def render_tags(self, template, context):
         """Renders all the tags in a template for a context."""
-        repCount = 0
-        while 1:
-            if repCount > 100:
-                print("too many replacements")
-                break
-            repCount += 1
-
-            match = self.tag_re.search(template)
-            if match is None:
-                break
-
-            tag, tag_type, tag_name = match.group(0, 1, 2)
-            tag_name = tag_name.strip()
-            try:
-                func = modifiers[tag_type]
-                replacement = func(self, tag_name, context)
-                template = template.replace(tag, replacement)
-            except (SyntaxError, KeyError):
-                return "{{invalid template}}"
-
-        return template
+        try:
+            return self.tag_re.sub((lambda match: self.sub_tag(match, context),template)
+        except (SyntaxError, KeyError):
+            return "{{invalid template}}"
 
     # {{{ functions just like {{ in anki
     @modifier('{')
@@ -159,7 +150,7 @@ class Template:
             mods, tag = parts[:-1], parts[-1] #py3k has *mods, tag = parts
 
         txt = get_or_attr(context, tag)
-        
+
         #Since 'text:' and other mods can affect html on which Anki relies to
         #process clozes, we need to make sure clozes are always
         #treated after all the other mods, regardless of how they're specified

--- a/anki/template/template.py
+++ b/anki/template/template.py
@@ -80,7 +80,7 @@ class Template:
         # val will contain the content of the field considered
         # right now
         val = None
-        m = re.match("c[qa]:(\d+):(.+)", section_name)
+        m = re.match(r"c[qa]:(\d+):(.+)", section_name)
         if m:
             # get full field text
             txt = get_or_attr(context, m.group(2), None)
@@ -96,7 +96,7 @@ class Template:
         if val:
             val = stripHTMLMedia(val).strip()
         if (val and not inverted) or (not val and inverted):
-                replacer = inner
+            replacer = inner
         return replacer
 
     def render_sections(self, template, context):

--- a/anki/template/template.py
+++ b/anki/template/template.py
@@ -117,7 +117,7 @@ class Template:
     def render_tags(self, template, context):
         """Renders all the tags in a template for a context."""
         try:
-            return self.tag_re.sub((lambda match: self.sub_tag(match, context),template)
+            return self.tag_re.sub(lambda match: self.sub_tag(match, context),template)
         except (SyntaxError, KeyError):
             return "{{invalid template}}"
 

--- a/anki/template/template.py
+++ b/anki/template/template.py
@@ -73,7 +73,7 @@ class Template:
         tag = r"%(otag)s(#|=|&|!|>|\{)?(.+?)\1?%(ctag)s+"
         self.tag_re = re.compile(tag % tags)
 
-    def sub_section(self, match):
+    def sub_section(self, match, context):
         section, section_name, inner = match.group(0, 1, 2)
         section_name = section_name.strip()
 
@@ -103,7 +103,7 @@ class Template:
         """Expands sections."""
         n = 1
         while n:
-            template, n = self.section_re.subn(self.sub_section, template)
+            template, n = self.section_re.subn(lambda match:self.sub_section(match,context), template)
         return template
 
     def sub_tag(self, match, context):


### PR DESCRIPTION
This code from add-on 115825506. No bug report were sent (only 8
downloads)

On a note type with a hundred card type and field, this improve the
computation of req from 7 minutes and a half to less than 3 minutes.

For badly formatted card, it may change the error message. Otherwise,
it should return the same card. One exception beeing if a tag occur in
the value of a field, in this case this won't be replaced
recursively.