### PR TITLE
I discovered a bug introduced by #271. I'm correcting it

### DIFF
--- a/anki/models.py
+++ b/anki/models.py
@@ -395,16 +395,18 @@ update cards set ord = ord - 1, usn = ?, mod = ?
         self._updateTemplOrds(m)
         # generate change map
         map = []
+        oldidxChanged = []
         for t in m['tmpls']:
             oldidx = oldidxs[id(t)]
             newidx = t['ord']
             if oldidx != newidx:
                 map.append("when ord = %d then %d" % (oldidx, newidx))
+                oldidxChanged.append(oldidx)
         # apply
         self.save(m)
         self.col.db.execute("""
 update cards set ord = (case %s end),usn=?,mod=? where nid in (
-select id from notes where mid = ?)""" % " ".join(map),
+select id from notes where mid = ?) and ord in %s""" % (" ".join(map),ids2str(oldidxChanged)),
                              self.col.usn(), intTime(), m['id'])
 
     def _syncTemplates(self, m):


### PR DESCRIPTION
This bug occurs only if:
* you are moving a card type CT of a note type NT
* there is a card already existing, whose note type is NT, and whose
  ord is not changed

This lead to the following error messsage

Error
An error occurred. Please use Tools > Check Database to see if that fixes the problem.
If problems persist, please report the problem on our support site. Please copy and paste the information below into your report.
Anki 2.1.9 (ae67c976) Python 3.6.7 Qt 5.12.1 PyQt 5.11.3
Platform: Linux
Flags: frz=True ao=False sv=1

Caught exception:
  File "aqt/clayout.py", line 373, in onReorder
  File "anki/models.py", line 409, in moveTemplate
  File "anki/db.py", line 32, in execute
<class 'sqlite3.IntegrityError'>: NOT NULL constraint failed: cards.ord

It seems I totally forgot to state that the request would apply only
to changed cards. I've no clue why I never noticed the error
before.

Thanks to the «not null» condition, those cards keep existing.
However, the bad news is that the card type order did change. Thus
those cards are now related to an uncorrect card type.

The user can correct this using the «change model». But this is not a
simple task. And there is no way to do this automatically since there
is no log of change which occurred.

Furthermore, if the user used «empty cards», some cards with an
incorrect number may have been deleted.



I present you my excuse