### PR TITLE
mpv: do not autoload user scripts

### DIFF
--- a/anki/mpv.py
+++ b/anki/mpv.py
@@ -75,6 +75,7 @@ class MPVBase:
         "--ontop",
         "--audio-display=no",
         "--keep-open=no",
+        "--load-scripts=no",
     ]
 
     def __init__(self, window_id=None, debug=False):


### PR DESCRIPTION
mpv users scripts can have unexpected results, so it's better not to load them.

In my case I had autoload.lua in my autoloaded user scripts, and Anki would
playback all the audio files in my deck as a result (since they share the
first few characters in the filename).

Relevant docs: https://mpv.io/manual/master/#options-load-scripts

(I haven't run the patch, but it should be trivial enough)