### PR TITLE
Recompute req only when it may be required.

### DIFF
--- a/anki/collection.py
+++ b/anki/collection.py
@@ -773,7 +773,7 @@ select id from notes where mid not in """ + ids2str(self.models.ids()))
                 if t['did'] == "None":
                     t['did'] = None
                     problems.append(_("Fixed AnkiDroid deck override bug."))
-                    self.models.save(m)
+                    self.models.save(m, recomputeReq=False)
             if m['type'] == MODEL_STD:
                 # model with missing req specification
                 if 'req' not in m:

--- a/anki/importing/mnemo.py
+++ b/anki/importing/mnemo.py
@@ -125,7 +125,7 @@ acq_reps+ret_reps, lapses, card_type_id from cards"""):
             model = addBasicModel(self.col)
             model['name'] = "Mnemosyne-FrontOnly"
         mm = self.col.models
-        mm.save(model)
+        mm.save(model, recomputeReq=True)
         mm.setCurrent(model)
         self.model = model
         self._fields = len(model['flds'])
@@ -189,7 +189,7 @@ acq_reps+ret_reps, lapses, card_type_id from cards"""):
         model = addClozeModel(self.col)
         model['name'] = "Mnemosyne-Cloze"
         mm = self.col.models
-        mm.save(model)
+        mm.save(model, recomputeReq=True)
         mm.setCurrent(model)
         self.model = model
         self._fields = len(model['flds'])

--- a/anki/importing/pauker.py
+++ b/anki/importing/pauker.py
@@ -18,7 +18,7 @@ class PaukerImporter(NoteImporter):
     def run(self):
         model = addForwardReverse(self.col)
         model['name'] = "Pauker"
-        self.col.models.save(model)
+        self.col.models.save(model, recomputeReq=True)
         self.col.models.setCurrent(model)
         self.model = model
         self.initMapping()

--- a/anki/importing/supermemo_xml.py
+++ b/anki/importing/supermemo_xml.py
@@ -84,7 +84,7 @@ class SupermemoXmlImporter(NoteImporter):
         NoteImporter.__init__(self, *args)
         m = addBasicModel(self.col)
         m['name'] = "Supermemo"
-        self.col.models.save(m)
+        self.col.models.save(m, recomputeReq=True)
         self.initMapping()
 
         self.lines = None

--- a/anki/models.py
+++ b/anki/models.py
@@ -82,12 +82,13 @@ class ModelManager:
         self.changed = False
         self.models = json.loads(json_)
 
-    def save(self, m=None, templates=False):
+    def save(self, m=None, templates=False, recomputeReq=True):
         "Mark M modified if provided, and schedule registry flush."
         if m and m['id']:
             m['mod'] = intTime()
             m['usn'] = self.col.usn()
-            self._updateRequired(m)
+            if recomputeReq:
+                self._updateRequired(m)
             if templates:
                 self._syncTemplates(m)
         self.changed = True

--- a/anki/storage.py
+++ b/anki/storage.py
@@ -96,7 +96,7 @@ def _upgrade(col, ver):
         for m in col.models.all():
             if not "{{cloze:" in m['tmpls'][0]['qfmt']:
                 m['type'] = MODEL_STD
-                col.models.save(m)
+                col.models.save(m, recomputeReq=True)
             else:
                 clozes.append(m)
         for m in clozes:
@@ -117,7 +117,7 @@ def _upgrade(col, ver):
                 m['css'] += "\n" + t['css'].replace(
                     ".card ", ".card%d "%(t['ord']+1))
                 del t['css']
-            col.models.save(m)
+            col.models.save(m, recomputeReq=True)
         col.db.execute("update col set ver = 6")
     if ver < 7:
         col.modSchema(check=False)
@@ -181,7 +181,7 @@ update cards set left = left + left*1000 where queue = 1""")
             for t in m['tmpls']:
                 t['bqfmt'] = ''
                 t['bafmt'] = ''
-            col.models.save(m)
+            col.models.save(m, recomputeReq=True)
         col.db.execute("update col set ver = 11")
 
 def _upgradeClozeModel(col, m):
@@ -200,7 +200,7 @@ def _upgradeClozeModel(col, m):
         col.models.remTemplate(m, r)
     del m['tmpls'][1:]
     col.models._updateTemplOrds(m)
-    col.models.save(m)
+    col.models.save(m, recomputeReq=True)
 
 # Creating a new collection
 ######################################################################

--- a/aqt/clayout.py
+++ b/aqt/clayout.py
@@ -549,7 +549,7 @@ Enter deck to place new %s cards in, or leave blank:""") %
                 self.note[name] = ""
             self.mw.col.db.execute("delete from notes where id = ?",
                                    self.note.id)
-        self.mm.save(self.model, templates=True)
+        self.mm.save(self.model, templates=True, recomputeReq=False)
         self.mw.reset()
         saveGeom(self, "CardLayout")
         return QDialog.reject(self)

--- a/aqt/editor.py
+++ b/aqt/editor.py
@@ -128,7 +128,7 @@ class Editor:
             return 'data:%s;base64,%s' % (mime, data64.decode('ascii'))
 
 
-    def addButton(self, icon, cmd, func, tip="", label="", 
+    def addButton(self, icon, cmd, func, tip="", label="",
                   id=None, toggleable=False, keys=None, disables=True):
         """Assign func to bridge cmd, register shortcut, return button"""
         if cmd not in self._links:
@@ -452,7 +452,7 @@ class Editor:
             # save tags to model
             m = self.note.model()
             m['tags'] = self.note.tags
-            self.mw.col.models.save(m)
+            self.mw.col.models.save(m, recomputeReq=False)
 
     def hideCompleters(self):
         self.tags.hideCompleter()

--- a/aqt/fields.py
+++ b/aqt/fields.py
@@ -156,7 +156,7 @@ class FieldDialog(QDialog):
             self.mw.progress.start()
             self.mw.col.updateFieldCache(self.mm.nids(self.model))
             self.mw.progress.finish()
-        self.mm.save(self.model)
+        self.mm.save(self.model, recomputeReq=True)
         self.mw.reset()
         QDialog.reject(self)
 

--- a/aqt/importing.py
+++ b/aqt/importing.py
@@ -159,7 +159,7 @@ you can enter it here. Use \\t to represent tab."""),
         did = self.deck.selectedId()
         if did != self.importer.model['did']:
             self.importer.model['did'] = did
-            self.mw.col.models.save(self.importer.model)
+            self.mw.col.models.save(self.importer.model, recomputeReq=False)
         self.mw.col.decks.select(did)
         self.mw.progress.start(immediate=True)
         self.mw.checkpoint(_("Import"))

--- a/aqt/models.py
+++ b/aqt/models.py
@@ -56,7 +56,7 @@ class Models(QDialog):
         txt = getText(_("New name:"), default=self.model['name'])
         if txt[1] and txt[0]:
             self.model['name'] = txt[0]
-            self.mm.save(self.model)
+            self.mm.save(self.model, recomputeReq=False)
         self.updateModelsList()
 
     def updateModelsList(self):
@@ -75,7 +75,7 @@ class Models(QDialog):
 
     def modelChanged(self):
         if self.model:
-            self.saveModel()
+            self.saveModel(recomputeReq=False)
         idx = self.form.modelsList.currentRow()
         self.model = self.models[idx]
 
@@ -86,7 +86,7 @@ class Models(QDialog):
             if txt:
                 m['name'] = txt
             self.mm.ensureNameUnique(m)
-            self.mm.save(m)
+            self.mm.save(m, recomputeReq=True)
             self.updateModelsList()
 
     def onDelete(self):
@@ -120,8 +120,8 @@ class Models(QDialog):
         self.model['latexPre'] = str(frm.latexHeader.toPlainText())
         self.model['latexPost'] = str(frm.latexFooter.toPlainText())
 
-    def saveModel(self):
-        self.mm.save(self.model)
+    def saveModel(self, recomputeReq=True):
+        self.mm.save(self.model, recomputeReq=recomputeReq)
 
     def _tmpNote(self):
         self.mm.setCurrent(self.model)
@@ -152,7 +152,7 @@ class Models(QDialog):
     # need to flush model on change or reject
 
     def reject(self):
-        self.saveModel()
+        self.saveModel(recomputeReq=True)
         self.mw.reset()
         saveGeom(self, "models")
         QDialog.reject(self)


### PR DESCRIPTION
Currently, anki.models.save recomputer the requirements of the model
saved. (Assuming a model is given as argument).

This computation may be long when there are many card type and
fields. And furthermore, this computation is often useless.  As an
example, on my computer, it takes 4 seconds for the model I use the most.

Let me give you one important example. Each time a new note is
created, the model is changed so that the new deck id of the model is
the current deck id. It seems quite clear that there is absolutely no
reason here to recompute the requirements. It means that between each
note I create, I should wait 4 seconds uselessly.

Thus, I added an optional parameter to ```anki.models.save```,
```recomputeReq```, which simply state whether the requirements should
be recomputed or not. By default, its value is True, thus the default
value ensure that the method act as before. Hence, an add-on using
this method won't see any change.

I also reviewed every occurrences of ```mm.save```,
```models.save``` in which a model is passed as argument, and I wrote
explicitly whether requirements should be recomputed or not.

A similar change was done to ```aqt.models.saveModel```,  where I
have chosen that the requirements are recomputed when the note type
window is closed (instead of recomputing it each time we decide to see
another card type)