### PR TITLE
Fix timestamp comparison failing when update API returns null

### DIFF
--- a/aqt/addons.py
+++ b/aqt/addons.py
@@ -325,7 +325,7 @@ Are you sure you want to continue?"""
         updated = []
         for dir, ts in mods:
             sid = str(dir)
-            if self.addonMeta(sid).get("mod",0) < ts:
+            if self.addonMeta(sid).get("mod", 0) < (ts or 0):
                 updated.append(sid)
         return updated
 


### PR DESCRIPTION
Addresses a rare instance of update checks failing when locally installed packages point to a shared ID that has yet to be updated to 2.1. In those instances Anki's update API returns null, which causes a TypeError downstream when comparing the timestamps against each other.