### PR TITLE
Disable add-on config button when no config present

### DIFF
--- a/aqt/addons.py
+++ b/aqt/addons.py
@@ -496,7 +496,9 @@ class AddonsDialog(QDialog):
             addon = self.addons[row_int][1]
         except IndexError:
             addon = ''
-        self.form.viewPage.setEnabled(bool (re.match(r"^\d+$", addon)))
+        self.form.viewPage.setEnabled(bool(re.match(r"^\d+$", addon)))
+        self.form.config.setEnabled(bool(self.mgr.getConfig(addon) or
+                                         self.mgr.configAction(addon)))
 
     def selectedAddons(self):
         idxs = [x.row() for x in self.form.addonList.selectedIndexes()]


### PR DESCRIPTION
Saw [this feature request ](https://anki.tenderapp.com/discussions/ankidesktop/33602-disable-the-config-button-when-an-add-on-is-highlighted-that-does-not-have-any-config) by George and thought it would be a quick and fun change to work on. Hope you don't mind!

