### PR TITLE
Clean up imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ aqt/forms
 locale
 tools/runanki.system
 anki/buildhash.py
+*_cache*

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,4 +1,65 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-whitelist=PyQt5
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=forms
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=0
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
 [MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
 disable=C,R,
   fixme,
   unused-wildcard-import,
@@ -13,3 +74,419 @@ disable=C,R,
   global-statement,
   protected-access,
   arguments-differ,
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=colorized
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package..
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,
+               dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style.
+#class-attribute-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style.
+#variable-rgx=
+
+
+[IMPORTS]
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=optparse,tkinter.tix
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled).
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled).
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=cls
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement.
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception".
+overgeneral-exceptions=Exception

--- a/anki/__init__.py
+++ b/anki/__init__.py
@@ -11,5 +11,6 @@ if sys.getfilesystemencoding().lower() in ("ascii", "ansi_x3.4-1968"):
     raise Exception("Anki requires a UTF-8 locale.")
 
 version="2.1.12" # build scripts grep this line, so preserve formatting
-from anki.storage import Collection
+
+from .storage import Collection  # noqa
 __all__ = ["Collection"]

--- a/anki/cards.py
+++ b/anki/cards.py
@@ -2,11 +2,11 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 import pprint
-
 import time
-from anki.hooks import runHook
-from anki.utils import intTime, timestampID, joinFields
-from anki.consts import *
+
+from .consts import MODEL_STD
+from .hooks import runHook
+from .utils import intTime, timestampID, joinFields
 
 # Cards
 ##########################################################################

--- a/anki/consts.py
+++ b/anki/consts.py
@@ -2,7 +2,10 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-from anki.lang import _
+from .lang import _
+
+SECONDS_IN_HOUR = 60 * 60
+SECONDS_IN_DAY = 24 * 60 * 60
 
 # whether new cards should be mixed with reviews, or shown first or last
 NEW_CARDS_DISTRIBUTE = 0

--- a/anki/decks.py
+++ b/anki/decks.py
@@ -2,15 +2,21 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-import copy, operator
-import unicodedata
+import copy
 import json
+import operator
+import unicodedata
 
-from anki.utils import intTime, ids2str
-from anki.hooks import runHook
-from anki.consts import *
-from anki.lang import _
+# from anki.consts import *
+from anki.consts import (
+    NEW_CARDS_DUE,
+    REM_DECK,
+    STARTING_FACTOR,
+)
 from anki.errors import DeckRenameError
+from anki.hooks import runHook
+from anki.lang import _
+from anki.utils import intTime, ids2str
 
 # fixmes:
 # - make sure users can't set grad interval < 1

--- a/anki/exporting.py
+++ b/anki/exporting.py
@@ -2,13 +2,18 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-import re, os, zipfile, shutil, unicodedata
 import json
+import os
+import re
+import shutil
+import unicodedata
+import zipfile
 
+from anki import Collection
+from anki.hooks import runHook
 from anki.lang import _
 from anki.utils import ids2str, splitFields, namedtmp, stripHTML
-from anki.hooks import runHook
-from anki import Collection
+
 
 class Exporter:
     includeHTML = None

--- a/anki/find.py
+++ b/anki/find.py
@@ -6,16 +6,22 @@ import re
 import sre_constants
 import unicodedata
 
-from anki.utils import ids2str, splitFields, joinFields, intTime, fieldChecksum, stripHTMLMedia
-from anki.consts import *
-from anki.hooks import *
-
+from anki.consts import MODEL_CLOZE
+from anki.hooks import runHook
+from anki.utils import (
+    fieldChecksum,
+    ids2str,
+    intTime,
+    joinFields,
+    splitFields,
+    stripHTMLMedia,
+)
 
 # Find
 ##########################################################################
 
-class Finder:
 
+class Finder:
     def __init__(self, col):
         self.col = col
         self.search = dict(

--- a/anki/importing/__init__.py
+++ b/anki/importing/__init__.py
@@ -2,12 +2,12 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-from anki.importing.csvfile import TextImporter
-from anki.importing.apkg import AnkiPackageImporter
 from anki.importing.anki2 import Anki2Importer
-from anki.importing.supermemo_xml import SupermemoXmlImporter
+from anki.importing.apkg import AnkiPackageImporter
+from anki.importing.csvfile import TextImporter
 from anki.importing.mnemo import MnemosyneImporter
 from anki.importing.pauker import PaukerImporter
+from anki.importing.supermemo_xml import SupermemoXmlImporter
 from anki.lang import _
 
 Importers = (

--- a/anki/importing/anki2.py
+++ b/anki/importing/anki2.py
@@ -4,14 +4,16 @@
 
 import os
 import unicodedata
+
 from anki import Collection
-from anki.utils import intTime, splitFields, joinFields
 from anki.importing.base import Importer
 from anki.lang import _
+from anki.utils import intTime, splitFields, joinFields
 
 GUID = 1
 MID = 2
 MOD = 3
+
 
 class Anki2Importer(Importer):
 

--- a/anki/importing/apkg.py
+++ b/anki/importing/apkg.py
@@ -2,11 +2,14 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-import zipfile, os
-import unicodedata
 import json
+import os
+import unicodedata
+import zipfile
+
 from anki.utils import tmpfile
 from anki.importing.anki2 import Anki2Importer
+
 
 class AnkiPackageImporter(Anki2Importer):
 

--- a/anki/importing/base.py
+++ b/anki/importing/base.py
@@ -2,10 +2,11 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-from anki.utils import  maxID
+from anki.utils import maxID
 
 # Base importer
 ##########################################################################
+
 
 class Importer:
 

--- a/anki/importing/mnemo.py
+++ b/anki/importing/mnemo.py
@@ -2,11 +2,14 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-import time, re
+import re
+import time
+
 from anki.db import DB
 from anki.importing.noteimp import NoteImporter, ForeignNote, ForeignCard
+from anki.lang import _, ngettext
 from anki.stdmodels import addBasicModel, addClozeModel
-from anki.lang import ngettext, _
+
 
 class MnemosyneImporter(NoteImporter):
 

--- a/anki/importing/noteimp.py
+++ b/anki/importing/noteimp.py
@@ -2,16 +2,21 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-import  html
-
+import html
 import unicodedata
 
 from anki.consts import NEW_CARDS_RANDOM, STARTING_FACTOR
-from anki.lang import _
-from anki.utils import fieldChecksum, guid64, timestampID, \
-    joinFields, intTime, splitFields
 from anki.importing.base import Importer
+from anki.lang import _
 from anki.lang import ngettext
+from anki.utils import (
+    fieldChecksum,
+    guid64,
+    timestampID,
+    joinFields,
+    intTime,
+    splitFields,
+)
 
 # Stores a list of fields, tags and deck
 ######################################################################

--- a/anki/importing/pauker.py
+++ b/anki/importing/pauker.py
@@ -2,7 +2,12 @@
 # Copyright: Andreas Klauer <Andreas.Klauer@metamorpher.de>
 # License: BSD-3
 
-import gzip, math, random, time, html
+import gzip
+import math
+import random
+import time
+import html
+
 import xml.etree.ElementTree as ET
 from anki.importing.noteimp import NoteImporter, ForeignNote, ForeignCard
 from anki.stdmodels import addForwardReverse

--- a/anki/importing/supermemo_xml.py
+++ b/anki/importing/supermemo_xml.py
@@ -2,16 +2,18 @@
 # Copyright: petr.michalec@gmail.com
 # License: GNU GPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
+import re
 import sys
+import time
+import unicodedata
 
-from anki.stdmodels import addBasicModel
-from anki.importing.noteimp import NoteImporter, ForeignNote, ForeignCard
-from anki.lang import _
-from anki.lang import ngettext
-
-from xml.dom import minidom
 from string import capwords
-import re, unicodedata, time
+from xml.dom import minidom
+
+from anki.importing.noteimp import NoteImporter, ForeignNote, ForeignCard
+from anki.lang import _, ngettext
+from anki.stdmodels import addBasicModel
+
 
 class SmartDict(dict):
     """

--- a/anki/lang.py
+++ b/anki/lang.py
@@ -2,8 +2,10 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-import os, sys, re
 import gettext
+import os
+import re
+import sys
 import threading
 
 langs = [

--- a/anki/latex.py
+++ b/anki/latex.py
@@ -2,10 +2,14 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-import re, os, shutil, html
-from anki.utils import checksum, call, namedtmp, tmpdir, isMac, stripHTML
+import html
+import os
+import re
+import shutil
+
 from anki.hooks import addHook
 from anki.lang import _
+from anki.utils import checksum, call, namedtmp, tmpdir, isMac, stripHTML
 
 pngCommands = [
     ["latex", "-interaction=nonstopmode", "tmp.tex"],

--- a/anki/media.py
+++ b/anki/media.py
@@ -1,22 +1,34 @@
 # -*- coding: utf-8 -*-
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
 import io
-import re
-import traceback
-import urllib.request, urllib.parse, urllib.error
-import unicodedata
-import sys
-import zipfile
-import pathlib
 import json
 import os
+import pathlib
+import re
+import sys
+import traceback
+import unicodedata
+import urllib.error
+import urllib.parse
+import urllib.request
+import zipfile
 
-from anki.utils import checksum, isWin, isMac
-from anki.db import DB, DBError
-from anki.consts import *
-from anki.latex import mungeQA
-from anki.lang import _
+from .consts import (
+    MODEL_CLOZE,
+    SYNC_ZIP_COUNT,
+    SYNC_ZIP_SIZE,
+)
+from .db import DB, DBError
+from .lang import _
+from .latex import mungeQA
+from .template.template import clozeReg
+from .utils import checksum, isWin, isMac
+
+if isWin:
+    import win32api  # pylint: disable=import-error
+    import win32file  # pylint: disable=import-error
 
 class MediaManager:
 
@@ -127,8 +139,6 @@ create table meta (dirMod int, lastUsn int); insert into meta values (0, 0);
     def _isFAT32(self):
         if not isWin:
             return
-        # pylint: disable=import-error
-        import win32api, win32file
         try:
             name = win32file.GetVolumeNameForVolumeMountPoint(self._dir[:3])
         except:
@@ -218,7 +228,6 @@ create table meta (dirMod int, lastUsn int); insert into meta values (0, 0);
     def _expandClozes(self, string):
         ords = set(re.findall(r"{{c(\d+)::.+?}}", string))
         strings = []
-        from anki.template.template import clozeReg
         def qrepl(m):
             if m.group(4):
                 return "[%s]" % m.group(4)

--- a/anki/models.py
+++ b/anki/models.py
@@ -2,13 +2,15 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-import copy, re, json
-from anki.utils import intTime, joinFields, splitFields, ids2str,\
-    checksum
-from anki.lang import _
-from anki.consts import *
-from anki.hooks import runHook
+import copy
+import json
+import re
 import time
+
+from anki.consts import MODEL_CLOZE, MODEL_STD
+from anki.hooks import runHook
+from anki.lang import _
+from anki.utils import intTime, joinFields, splitFields, ids2str, checksum
 
 # Models
 ##########################################################################

--- a/anki/mpv.py
+++ b/anki/mpv.py
@@ -25,19 +25,27 @@
 #
 # ------------------------------------------------------------------------------
 
-import sys
-import os
-import time
+import inspect
 import json
-import socket
+import os
 import select
+import socket
+import subprocess
+import sys
 import tempfile
 import threading
-import subprocess
-import inspect
+import time
 
 from distutils.spawn import find_executable # pylint: disable=import-error,no-name-in-module
 from queue import Queue, Empty, Full
+
+from .utils import isWin
+
+if isWin:
+    import win32file  # pylint: disable=import-error
+    import win32pipe  # pylint: disable=import-error
+    import pywintypes  # pylint: disable=import-error
+    import winerror  # pylint: disable=import-error
 
 
 class MPVError(Exception):
@@ -55,10 +63,6 @@ class MPVCommandError(MPVError):
 class MPVTimeoutError(MPVError):
     pass
 
-from anki.utils import isWin
-if isWin:
-    # pylint: disable=import-error
-    import win32file, win32pipe, pywintypes, winerror
 
 class MPVBase:
     """Base class for communication with the mpv media player via unix socket

--- a/anki/notes.py
+++ b/anki/notes.py
@@ -2,11 +2,18 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-from anki.utils import fieldChecksum, intTime, \
-    joinFields, splitFields, stripHTMLMedia, timestampID, guid64
+from .utils import (
+    fieldChecksum,
+    guid64,
+    intTime,
+    joinFields,
+    splitFields,
+    stripHTMLMedia,
+    timestampID,
+)
+
 
 class Note:
-
     def __init__(self, col, model=None, id=None):
         assert not (model and id)
         self.col = col

--- a/anki/sched.py
+++ b/anki/sched.py
@@ -5,18 +5,35 @@
 import time
 import random
 import itertools
-from operator import itemgetter
-from heapq import *
 
-#from anki.cards import Card
-from anki.utils import ids2str, intTime, fmtTimeSpan
-from anki.lang import _
-from anki.consts import *
-from anki.hooks import runHook
+from operator import itemgetter
+from heapq import heappush, heappop
+
+from .consts import (
+    DYN_ADDED,
+    DYN_BIGINT,
+    DYN_DUE,
+    DYN_DUEPRIORITY,
+    DYN_LAPSES,
+    DYN_OLDEST,
+    DYN_RANDOM,
+    DYN_REVADDED,
+    DYN_SMALLINT,
+    NEW_CARDS_DISTRIBUTE,
+    NEW_CARDS_DUE,
+    NEW_CARDS_FIRST,
+    NEW_CARDS_LAST,
+    NEW_CARDS_RANDOM,
+    STARTING_FACTOR,
+)
+from .hooks import runHook
+from .lang import _
+from .utils import ids2str, intTime, fmtTimeSpan
 
 # queue types: 0=new/cram, 1=lrn, 2=rev, 3=day lrn, -1=suspended, -2=buried
 # revlog types: 0=lrn, 1=rev, 2=relrn, 3=cram
 # positive revlog intervals are in days (rev), negative in seconds (lrn)
+
 
 class Scheduler:
     name = "std"

--- a/anki/schedv2.py
+++ b/anki/schedv2.py
@@ -2,17 +2,35 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-import time
-import random
-import itertools
-from operator import itemgetter
-from heapq import *
 import datetime
+import itertools
+import random
+import time
 
-from anki.utils import ids2str, intTime, fmtTimeSpan
-from anki.lang import _
-from anki.consts import *
-from anki.hooks import runHook
+from heapq import heappop, heappush
+from operator import itemgetter
+
+from .consts import (
+    DYN_ADDED,
+    DYN_BIGINT,
+    DYN_DUE,
+    DYN_DUEPRIORITY,
+    DYN_LAPSES,
+    DYN_OLDEST,
+    DYN_RANDOM,
+    DYN_REVADDED,
+    DYN_SMALLINT,
+    NEW_CARDS_DISTRIBUTE,
+    NEW_CARDS_DUE,
+    NEW_CARDS_FIRST,
+    NEW_CARDS_LAST,
+    NEW_CARDS_RANDOM,
+    STARTING_FACTOR,
+)
+from .hooks import runHook
+from .lang import _
+from .utils import ids2str, intTime, fmtTimeSpan
+
 
 # card types: 0=new, 1=lrn, 2=rev, 3=relrn
 # queue types: 0=new, 1=(re)lrn, 2=rev, 3=day (re)lrn,

--- a/anki/sound.py
+++ b/anki/sound.py
@@ -2,12 +2,20 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
+import atexit
 import html
-import re, sys, threading, time, subprocess, os, atexit
-import  random
-from anki.hooks import addHook, runHook
-from anki.utils import  tmpdir, isWin, isMac, isLin
-from anki.lang import _
+import os
+import random
+import re
+import subprocess
+import sys
+import threading
+import time
+
+from .hooks import addHook, runHook
+from .lang import _
+from .mpv import MPV, MPVBase
+from .utils import tmpdir, isWin, isMac, isLin
 
 # Shared utils
 ##########################################################################
@@ -85,8 +93,6 @@ def retryWait(proc):
 
 # MPV
 ##########################################################################
-
-from anki.mpv import MPV, MPVBase
 
 mpvPath, mpvEnv = _packagedCmd(["mpv"])
 
@@ -316,7 +322,7 @@ try:
     PYAU_FORMAT = pyaudio.paInt16
     PYAU_CHANNELS = 1
     PYAU_INPUT_INDEX = None
-except:
+except ImportError:
     pyaudio = None
 
 class _Recorder:
@@ -405,7 +411,7 @@ class PyAudioRecorder(_Recorder):
             return processingSrc
 
 if not pyaudio:
-    PyAudioRecorder = None
+    PyAudioRecorder = None  # noqa
 
 # Audio interface
 ##########################################################################

--- a/anki/stats.py
+++ b/anki/stats.py
@@ -2,13 +2,13 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-import time
 import datetime
 import json
+import time
 
-from anki.utils import fmtTimeSpan, ids2str
-from anki.lang import _, ngettext
-
+from .lang import _, ngettext
+from .statsbg import bg as stats_bg
+from .utils import fmtTimeSpan, ids2str
 
 # Card stats
 ##########################################################################
@@ -112,8 +112,7 @@ class CollectionStats:
     def report(self, type=0):
         # 0=days, 1=weeks, 2=months
         self.type = type
-        from .statsbg import bg
-        txt = self.css % bg
+        txt = self.css % stats_bg
         txt += self._section(self.todayStats())
         txt += self._section(self.dueGraph())
         txt += self.repsGraphs()

--- a/anki/stdmodels.py
+++ b/anki/stdmodels.py
@@ -2,8 +2,8 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-from anki.lang import _
-from anki.consts import MODEL_CLOZE
+from .consts import MODEL_CLOZE
+from .lang import _
 
 models = []
 

--- a/anki/storage.py
+++ b/anki/storage.py
@@ -3,17 +3,27 @@
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 import copy
-import re
 import json
 import os
+import re
 
-from anki.lang import _
-from anki.utils import intTime, isWin
-from anki.db import DB
-from anki.collection import _Collection
-from anki.consts import *
-from anki.stdmodels import addBasicModel, addClozeModel, addForwardReverse, \
-    addForwardOptionalReverse, addBasicTypingModel
+from .collection import _Collection
+from .consts import (
+    MODEL_CLOZE,
+    MODEL_STD,
+    SCHEMA_VERSION,
+)
+from .db import DB
+from .lang import _
+from .stdmodels import (
+    addBasicModel,
+    addBasicTypingModel,
+    addClozeModel,
+    addForwardOptionalReverse,
+    addForwardReverse,
+)
+from .utils import intTime, isWin
+
 
 def Collection(path, lock=True, server=False, log=False):
     "Open a new or existing collection. Path must be unicode."

--- a/anki/sync.py
+++ b/anki/sync.py
@@ -2,20 +2,34 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-import io
 import gzip
-import random
-import requests
+import io
 import json
 import os
+import random
+import requests
+import warnings
 
-from anki.db import DB, DBError
-from anki.utils import ids2str, intTime, platDesc, checksum, devMode
-from anki.consts import *
-from anki.utils import versionWithBuild
+from anki import version as anki_version
+
+from .consts import (
+    REM_CARD,
+    REM_NOTE,
+    SYNC_BASE,
+    SYNC_VER,
+    SYNC_ZIP_COUNT,
+)
+from .db import DB, DBError
 from .hooks import runHook
-import anki
 from .lang import ngettext
+from .utils import (
+    checksum,
+    devMode,
+    ids2str,
+    intTime,
+    platDesc,
+    versionWithBuild,
+)
 
 # syncing vars
 HTTP_TIMEOUT = 90
@@ -456,14 +470,12 @@ class AnkiRequestsClient:
         return buf.getvalue()
 
     def _agentName(self):
-        from anki import version
-        return "Anki {}".format(version)
+        return "Anki {}".format(anki_version)
 
 # allow user to accept invalid certs in work/school settings
 if os.environ.get("ANKI_NOVERIFYSSL"):
     AnkiRequestsClient.verify = False
 
-    import warnings
     warnings.filterwarnings("ignore")
 
 class _MonitoringFile(io.BufferedReader):
@@ -632,7 +644,7 @@ class FullSyncer(HttpSyncer):
         HttpSyncer.__init__(self, hkey, client, hostNum=hostNum)
         self.postVars = dict(
             k=self.hkey,
-            v="ankidesktop,%s,%s"%(anki.version, platDesc()),
+            v="ankidesktop,%s,%s"%(anki_version, platDesc()),
         )
         self.col = col
 
@@ -830,7 +842,7 @@ class RemoteMediaServer(HttpSyncer):
     def begin(self):
         self.postVars = dict(
             k=self.hkey,
-            v="ankidesktop,%s,%s"%(anki.version, platDesc())
+            v="ankidesktop,%s,%s"%(anki_version, platDesc())
         )
         ret = self._dataOnly(self.req(
             "begin", io.BytesIO(json.dumps(dict()).encode("utf8"))))

--- a/anki/tags.py
+++ b/anki/tags.py
@@ -11,9 +11,10 @@ This module manages the tag cache and tags for notes.
 """
 
 import json
-from anki.utils import intTime, ids2str
-from anki.hooks import runHook
 import re
+
+from .hooks import runHook
+from .utils import intTime, ids2str
 
 class TagManager:
 

--- a/anki/template/__init__.py
+++ b/anki/template/__init__.py
@@ -1,5 +1,5 @@
-from anki.template.template import Template
-from anki.template.view import View
+from .template import Template
+
 
 def render(template, context=None, **kwargs):
     context = context and context.copy() or {}

--- a/anki/template/furigana.py
+++ b/anki/template/furigana.py
@@ -4,7 +4,8 @@
 # Based off Kieran Clancy's initial implementation.
 
 import re
-from anki.hooks import addHook
+
+from ..hooks import addHook
 
 r = r' ?([^ >]+?)\[(.+?)\]'
 ruby = r'<ruby><rb>\1</rb><rt>\2</rt></ruby>'

--- a/anki/template/hint.py
+++ b/anki/template/hint.py
@@ -2,8 +2,9 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-from anki.hooks import addHook
-from anki.lang import _
+from ..hooks import addHook
+from ..lang import _
+
 
 def hint(txt, extra, context, tag, fullname):
     if not txt.strip():

--- a/anki/template/template.py
+++ b/anki/template/template.py
@@ -1,11 +1,14 @@
 import re
-from anki.utils import stripHTML, stripHTMLMedia
-from anki.hooks import runFilter
-from anki.template import furigana; furigana.install()
-from anki.template import hint; hint.install()
+
+from ..hooks import runFilter
+from ..utils import stripHTML, stripHTMLMedia
+
+from . import furigana, hint
+
+furigana.install()
+hint.install()
 
 clozeReg = r"(?si)\{\{(c)%s::(.*?)(::(.*?))?\}\}"
-
 modifiers = {}
 def modifier(symbol):
     """Decorator for associating a function with a Mustache tag modifier.
@@ -159,7 +162,7 @@ class Template:
             mods, tag = parts[:-1], parts[-1] #py3k has *mods, tag = parts
 
         txt = get_or_attr(context, tag)
-        
+
         #Since 'text:' and other mods can affect html on which Anki relies to
         #process clozes, we need to make sure clozes are always
         #treated after all the other mods, regardless of how they're specified

--- a/anki/template/view.py
+++ b/anki/template/view.py
@@ -1,6 +1,8 @@
-from anki.template import Template
 import os.path
 import re
+
+from . import Template
+
 
 class View:
     # Path where this view's template(s) live

--- a/anki/utils.py
+++ b/anki/utils.py
@@ -2,26 +2,33 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-import re
-import os
-import random
-import time
+# some add-ons expect json to be in the utils module
+import atexit
+import json # noqa pylint: disable=unused-import
+import locale
 import math
-from html.entities import name2codepoint
-import subprocess
-import tempfile
+import os
+import platform
+import random
+import re
 import shutil
 import string
+import subprocess
 import sys
-import locale
-from hashlib import sha1
-import platform
+import tempfile
+import time
 import traceback
-from contextlib import contextmanager
-from anki.lang import _, ngettext
 
-# some add-ons expect json to be in the utils module
-import json # pylint: disable=unused-import
+from contextlib import contextmanager
+from hashlib import sha1
+from html.entities import name2codepoint
+
+from . import version as anki_version
+from .lang import _, ngettext
+
+if platform.system() == 'Linux':
+    import distro  # pylint: disable=import-error
+
 
 # Time handling
 ##############################################################################
@@ -291,7 +298,6 @@ def tmpdir():
     if not _tmpdir:
         def cleanup():
             shutil.rmtree(_tmpdir)
-        import atexit
         atexit.register(cleanup)
         _tmpdir = os.path.join(tempfile.gettempdir(), "anki_temp")
     if not os.path.exists(_tmpdir):
@@ -389,7 +395,6 @@ def platDesc():
             elif isWin:
                 theos = "win:%s" % (platform.win32_ver()[0])
             elif system == "Linux":
-                import distro
                 r = distro.linux_distribution(full_distribution_name=False)
                 theos = "lin:%s:%s" % (r[0], r[1])
             else:
@@ -414,9 +419,8 @@ class TimedLog:
 ##############################################################################
 
 def versionWithBuild():
-    from anki import version
     try:
-        from anki.buildhash import build
+        from anki.buildhash import build  # pylint: disable=import-error,no-name-in-module
     except:
         build = "dev"
-    return "%s (%s)" % (version, build)
+    return "%s (%s)" % (anki_version, build)

--- a/aqt/about.py
+++ b/aqt/about.py
@@ -2,11 +2,21 @@
 # -*- coding: utf-8 -*-
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-from aqt.qt import *
-import aqt.forms
-from anki.utils import versionWithBuild
-from aqt.utils import supportText, tooltip
 from anki.lang import _
+from anki.utils import versionWithBuild
+
+import aqt.forms
+
+from aqt.qt import (
+    PYQT_VERSION_STR,
+    QApplication,
+    QDialog,
+    QDialogButtonBox,
+    QPushButton,
+    QT_VERSION_STR,
+)
+from aqt.utils import supportText, tooltip
+
 
 class ClosableQDialog(QDialog):
     def reject(self):

--- a/aqt/addcards.py
+++ b/aqt/addcards.py
@@ -2,15 +2,36 @@
 # -*- coding: utf-8 -*-
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 from anki.lang import _
-
-from aqt.qt import *
-import aqt.forms
-from aqt.utils import saveGeom, restoreGeom, showWarning, askUser, shortcut, \
-    tooltip, openHelp, addCloseShortcut, downArrow
 from anki.sound import clearAudioQueue
 from anki.hooks import addHook, remHook, runHook
 from anki.utils import htmlToTextLine, isMac
-import aqt.editor, aqt.modelchooser, aqt.deckchooser
+
+import aqt.deckchooser
+import aqt.editor
+import aqt.forms
+import aqt.modelchooser
+
+from aqt.qt import (
+    QDialog,
+    Qt,
+    QDialogButtonBox,
+    QKeySequence,
+    QPushButton,
+    QMenu,
+    QPoint
+)
+from aqt.utils import (
+    saveGeom,
+    restoreGeom,
+    showWarning,
+    askUser,
+    shortcut,
+    tooltip,
+    openHelp,
+    addCloseShortcut,
+    downArrow
+)
+
 
 class AddCards(QDialog):
 

--- a/aqt/browser.py
+++ b/aqt/browser.py
@@ -2,30 +2,94 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-import sre_constants
 import html
-import time
-import re
-import unicodedata
-from operator import  itemgetter
-from anki.lang import ngettext
 import json
+import re
+import sre_constants
+import time
+import unicodedata
 
-from aqt.qt import *
-import anki
-import aqt.forms
-from anki.utils import fmtTimeSpan, ids2str, htmlToTextLine, \
-    isWin, intTime, \
-    isMac, bodyClass
-from aqt.utils import saveGeom, restoreGeom, saveSplitter, restoreSplitter, \
-    saveHeader, restoreHeader, saveState, restoreState, getTag, \
-    showInfo, askUser, tooltip, openHelp, showWarning, shortcut, mungeQA, \
-    getOnlyText, MenuList, SubMenu, qtMenuShortcutWorkaround
-from anki.lang import _
+from operator import itemgetter
+
+import anki.find
+
+from anki.consts import MODEL_CLOZE
 from anki.hooks import runHook, addHook, remHook, runFilter
-from aqt.webview import AnkiWebView
-from anki.consts import *
+from anki.lang import ngettext, _
 from anki.sound import clearAudioQueue, allSounds, play
+from anki.stats import (
+    CardStats,
+    colCram,
+    colLearn,
+    colMature,
+    colRelearn,
+)
+from anki.utils import (
+    bodyClass,
+    fmtTimeSpan,
+    htmlToTextLine,
+    ids2str,
+    intTime,
+    isMac,
+    isWin,
+)
+
+import aqt.forms
+
+from aqt.qt import (
+    QAbstractItemView,
+    QAbstractTableModel,
+    QBrush,
+    QCheckBox,
+    QColor,
+    QComboBox,
+    QCursor,
+    QDialog,
+    QDialogButtonBox,
+    QDockWidget,
+    QFont,
+    QGridLayout,
+    QHBoxLayout,
+    QHeaderView,
+    QIcon,
+    QItemDelegate,
+    QItemSelection,
+    QItemSelectionModel,
+    QKeySequence,
+    QLabel,
+    QMainWindow,
+    QMenu,
+    QPalette,
+    QShortcut,
+    QTreeWidget,
+    QTreeWidgetItem,
+    QVBoxLayout,
+    QWidget,
+    Qt,
+)
+from aqt.utils import (
+    MenuList,
+    SubMenu,
+    askUser,
+    getOnlyText,
+    getTag,
+    mungeQA,
+    openHelp,
+    restoreGeom,
+    restoreHeader,
+    restoreSplitter,
+    restoreState,
+    saveGeom,
+    saveHeader,
+    saveSplitter,
+    saveState,
+    qtMenuShortcutWorkaround,
+    shortcut,
+    showInfo,
+    showWarning,
+    tooltip,
+)
+from aqt.webview import AnkiWebView
 
 
 # Data model
@@ -1148,7 +1212,6 @@ by clicking on one on the left."""))
         d.show()
 
     def _cardInfoData(self):
-        from anki.stats import CardStats
         cs = CardStats(self.col, self.card)
         rep = cs.report()
         m = self.card.model()
@@ -1173,20 +1236,19 @@ border: 1px solid #000; padding: 3px; '>%s</div>""" % rep
                                                    time.localtime(date))
             tstr = [_("Learn"), _("Review"), _("Relearn"), _("Filtered"),
                     _("Resched")][type]
-            import anki.stats as st
             fmt = "<span style='color:%s'>%s</span>"
             if type == 0:
-                tstr = fmt % (st.colLearn, tstr)
+                tstr = fmt % (colLearn, tstr)
             elif type == 1:
-                tstr = fmt % (st.colMature, tstr)
+                tstr = fmt % (colMature, tstr)
             elif type == 2:
-                tstr = fmt % (st.colRelearn, tstr)
+                tstr = fmt % (colRelearn, tstr)
             elif type == 3:
-                tstr = fmt % (st.colCram, tstr)
+                tstr = fmt % (colCram, tstr)
             else:
                 tstr = fmt % ("#000", tstr)
             if ease == 1:
-                ease = fmt % (st.colRelearn, ease)
+                ease = fmt % (colRelearn, ease)
             if ivl == 0:
                 ivl = _("0d")
             elif ivl > 0:
@@ -1736,7 +1798,6 @@ update cards set usn=?, mod=?, did=? where id in """ + scids,
         sf = self.selectedNotes()
         if not sf:
             return
-        import anki.find
         fields = anki.find.fieldNamesForNotes(self.mw.col, sf)
         d = QDialog(self)
         frm = aqt.forms.findreplace.Ui_Dialog()
@@ -2095,4 +2156,3 @@ Are you sure you want to continue?""")):
 
     def onHelp(self):
         openHelp("browsermisc")
-

--- a/aqt/clayout.py
+++ b/aqt/clayout.py
@@ -3,20 +3,48 @@
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 import collections
+import json
 import re
 
-from aqt.qt import *
-from anki.consts import *
-import aqt
-from anki.sound import playFromText, clearAudioQueue
-from aqt.utils import saveGeom, restoreGeom, mungeQA,\
-    showInfo, askUser, getOnlyText, \
-     showWarning, openHelp, downArrow
-from anki.utils import isMac, isWin, joinFields, bodyClass
-from aqt.webview import AnkiWebView
-import json
+from anki.consts import MODEL_CLOZE
 from anki.hooks import runFilter
 from anki.lang import _, ngettext
+from anki.sound import playFromText, clearAudioQueue
+from anki.utils import isMac, isWin, joinFields, bodyClass
+
+# Used to have mw available, don't import mw into the module directly
+# otherwise it can't be dynamically updated
+import aqt
+import aqt.forms
+
+from aqt.qt import (
+    QDialog,
+    QDialogButtonBox,
+    QFont,
+    QHBoxLayout,
+    QKeySequence,
+    QLabel,
+    QMenu,
+    QPoint,
+    QPushButton,
+    QShortcut,
+    QVBoxLayout,
+    QWidget,
+    Qt,
+)
+from aqt.utils import (
+    askUser,
+    downArrow,
+    getOnlyText,
+    mungeQA,
+    openHelp,
+    restoreGeom,
+    saveGeom,
+    showInfo,
+    showWarning,
+)
+from aqt.webview import AnkiWebView
+
 
 class CardLayout(QDialog):
 

--- a/aqt/customstudy.py
+++ b/aqt/customstudy.py
@@ -2,11 +2,19 @@
 # -*- coding: utf-8 -*-
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-from aqt.qt import *
-import aqt
-from aqt.utils import showInfo, showWarning
-from anki.consts import *
+from anki.consts import (
+    DYN_ADDED,
+    DYN_DUE,
+    DYN_MAX_SIZE,
+    DYN_OLDEST,
+    DYN_RANDOM,
+)
 from anki.lang import _
+
+import aqt.forms
+
+from aqt.qt import QDialog, QDialogButtonBox, Qt
+from aqt.utils import showInfo, showWarning
 
 RADIO_NEW = 1
 RADIO_REV = 2
@@ -19,6 +27,7 @@ TYPE_NEW = 0
 TYPE_DUE = 1
 TYPE_REVIEW = 2
 TYPE_ALL = 3
+
 
 class CustomStudy(QDialog):
     def __init__(self, mw):

--- a/aqt/deckbrowser.py
+++ b/aqt/deckbrowser.py
@@ -2,23 +2,34 @@
 # -*- coding: utf-8 -*-
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-from aqt.qt import *
-from aqt.utils import askUser, getOnlyText, openLink, showWarning, shortcut, \
-    openHelp
-from anki.utils import ids2str, fmtTimeSpan
-from anki.errors import DeckRenameError
-import aqt
-from anki.sound import clearAudioQueue
-from anki.hooks import runHook
 from copy import deepcopy
+
+from anki.errors import DeckRenameError
 from anki.lang import _, ngettext
+from anki.hooks import runHook
+from anki.sound import clearAudioQueue
+from anki.utils import ids2str, fmtTimeSpan
+
+from aqt import appShared
+from aqt.toolbar import BottomBar
+
+from aqt.qt import QPoint, QMenu, QCursor
+from aqt.utils import (
+    askUser,
+    getOnlyText,
+    openHelp,
+    openLink,
+    shortcut,
+    showWarning,
+)
+
 
 class DeckBrowser:
 
     def __init__(self, mw):
         self.mw = mw
         self.web = mw.web
-        self.bottom = aqt.toolbar.BottomBar(mw, mw.bottomWeb)
+        self.bottom = BottomBar(mw, mw.bottomWeb)
         self.scrollPos = QPoint(0, 0)
 
     def show(self):
@@ -293,4 +304,4 @@ where id > ?""", (self.mw.col.sched.dayCutoff-86400)*1000)
         self.bottom.web.onBridgeCmd = self._linkHandler
 
     def _onShared(self):
-        openLink(aqt.appShared+"decks/")
+        openLink(appShared+"decks/")

--- a/aqt/deckchooser.py
+++ b/aqt/deckchooser.py
@@ -2,10 +2,19 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-from aqt.qt import *
 from anki.hooks import addHook, remHook
-from aqt.utils import  shortcut
 from anki.lang import _
+
+from aqt.qt import (
+    QHBoxLayout,
+    QKeySequence,
+    QLabel,
+    QPushButton,
+    QShortcut,
+    QSizePolicy,
+)
+from aqt.utils import shortcut
+
 
 class DeckChooser(QHBoxLayout):
 

--- a/aqt/deckconf.py
+++ b/aqt/deckconf.py
@@ -1,14 +1,32 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # -*- coding: utf-8 -*-
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
 from operator import itemgetter
 
 from anki.consts import NEW_CARDS_RANDOM
-from aqt.qt import *
-import aqt
-from aqt.utils import showInfo, showWarning, openHelp, getOnlyText, askUser, \
-    tooltip, saveGeom, restoreGeom
 from anki.lang import _, ngettext
+
+import aqt.forms
+
+from aqt.qt import (
+    QCursor,
+    QDialog,
+    QDialogButtonBox,
+    QMenu,
+    Qt,
+)
+from aqt.utils import (
+    showInfo,
+    showWarning,
+    openHelp,
+    getOnlyText,
+    askUser,
+    tooltip,
+    saveGeom,
+    restoreGeom,
+)
+
 
 class DeckConf(QDialog):
     def __init__(self, mw, deck):

--- a/aqt/downloader.py
+++ b/aqt/downloader.py
@@ -2,12 +2,16 @@
 # -*- coding: utf-8 -*-
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-import time, re
-from aqt.qt import *
-from anki.sync import AnkiRequestsClient
+import time
+import re
+
 from anki.hooks import addHook, remHook
-import aqt
 from anki.lang import _
+from anki.sync import AnkiRequestsClient
+
+from aqt import appShared
+from aqt.qt import QThread, pyqtSignal
+
 
 def download(mw, code):
     "Download addon from AnkiWeb. Caller must start & stop progress diag."
@@ -53,7 +57,7 @@ class Downloader(QThread):
         client = AnkiRequestsClient()
         try:
             resp = client.get(
-                aqt.appShared + "download/%s?v=2.1" % self.code)
+                appShared + "download/%s?v=2.1" % self.code)
             if resp.status_code == 200:
                 data = client.streamContent(resp)
             elif resp.status_code in (403,404):

--- a/aqt/dyndeckconf.py
+++ b/aqt/dyndeckconf.py
@@ -2,10 +2,17 @@
 # -*- coding: utf-8 -*-
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-from aqt.qt import *
-import aqt
-from aqt.utils import  showWarning, openHelp, askUser, saveGeom, restoreGeom
 from anki.lang import _
+
+import aqt.forms
+
+from aqt.qt import (
+    QDialog,
+    QDialogButtonBox,
+    Qt,
+)
+from aqt.utils import showWarning, openHelp, askUser, saveGeom, restoreGeom
+
 
 class DeckConf(QDialog):
     def __init__(self, mw, first=False, search="", deck=None):

--- a/aqt/editcurrent.py
+++ b/aqt/editcurrent.py
@@ -2,13 +2,14 @@
 # -*- coding: utf-8 -*-
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-from aqt.qt import *
-from aqt.utils import tooltip
-import aqt.editor
-from aqt.utils import saveGeom, restoreGeom
 from anki.hooks import addHook, remHook
-from anki.utils import isMac
 from anki.lang import _
+
+import aqt.forms
+
+from aqt.editor import Editor
+from aqt.qt import QDialog, QDialogButtonBox, QKeySequence, Qt
+from aqt.utils import saveGeom, restoreGeom, tooltip
 
 class EditCurrent(QDialog):
 
@@ -23,7 +24,7 @@ class EditCurrent(QDialog):
         self.setMinimumWidth(500)
         self.form.buttonBox.button(QDialogButtonBox.Close).setShortcut(
                 QKeySequence("Ctrl+Return"))
-        self.editor = aqt.editor.Editor(self.mw, self.form.fieldsArea, self)
+        self.editor = Editor(self.mw, self.form.fieldsArea, self)
         self.editor.card = self.mw.reviewer.card
         self.editor.setNote(self.mw.reviewer.card.note(), focusTo=0)
         restoreGeom(self, "editcurrent")
@@ -52,7 +53,7 @@ class EditCurrent(QDialog):
     def reopen(self,mw):
         tooltip("Please finish editing the existing card first.")
         self.onReset()
-        
+
     def reject(self):
         self.saveAndClose()
 

--- a/aqt/editor.py
+++ b/aqt/editor.py
@@ -1,29 +1,52 @@
 # -*- coding: utf-8 -*-
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
-import re
-import urllib.request, urllib.parse, urllib.error
-import warnings
-import html
-import mimetypes
 import base64
-import unicodedata
+import html
 import json
-
-from anki.lang import _
-from aqt.qt import *
-from anki.utils import isWin, namedtmp, stripHTMLMedia, \
-    checksum
-import anki.sound
-from anki.hooks import runHook, runFilter, addHook
-from aqt.sound import getAudio
-from aqt.webview import AnkiWebView
-from aqt.utils import shortcut, showInfo, showWarning, getFile, \
-    openHelp, tooltip, qtMenuShortcutWorkaround
-import aqt
-from bs4 import BeautifulSoup
+import mimetypes
+import os
+import re
 import requests
+import unicodedata
+import urllib.error
+import urllib.parse
+import urllib.request
+import warnings
+
+from bs4 import BeautifulSoup
+
+import anki.sound
+
+from anki.hooks import runHook, runFilter, addHook
+from anki.lang import _
 from anki.sync import AnkiRequestsClient
+from anki.utils import isWin, namedtmp, stripHTMLMedia, checksum
+
+import aqt.forms
+import aqt.fields
+
+from aqt.qt import (
+    QClipboard,
+    QColor,
+    QColorDialog,
+    QCursor,
+    QVBoxLayout,
+    QDialog,
+    QGridLayout,
+    QGroupBox,
+    QImage,
+    QKeySequence,
+    QLabel,
+    QMenu,
+    QShortcut,
+    QTextCursor,
+    QWebEnginePage,
+    Qt,
+)
+from aqt.sound import getAudio
+from aqt.utils import shortcut, showInfo, showWarning, getFile, openHelp, tooltip, qtMenuShortcutWorkaround
+from aqt.webview import AnkiWebView
 
 pics = ("jpg", "jpeg", "png", "tif", "tiff", "gif", "svg", "webp")
 audio =  ("wav", "mp3", "ogg", "flac", "mp4", "swf", "mov", "mpeg", "mkv", "m4a", "3gp", "spx", "oga", "webm")

--- a/aqt/errors.py
+++ b/aqt/errors.py
@@ -1,14 +1,22 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # -*- coding: utf-8 -*-
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
-import sys, traceback
 import html
+import os
 import re
+import sys
+import traceback
 
 from anki.lang import _
-from aqt.qt import *
+
+from aqt import mw as aqt_mw
+from aqt.qt import (
+    QObject,
+    QTimer,
+    pyqtSignal,
+)
 from aqt.utils import showText, showWarning, supportText
-from aqt import mw
+
 
 if not os.environ.get("DEBUG"):
     def excepthook(etype,val,tb):
@@ -16,6 +24,7 @@ if not os.environ.get("DEBUG"):
             ''.join(traceback.format_tb(tb)),
             '{0}: {1}'.format(etype, val)))
     sys.excepthook = excepthook
+
 
 class ErrorHandler(QObject):
     "Catch stderr and write into buffer."
@@ -125,14 +134,14 @@ report the issue on the <a href="https://help.ankiweb.net/discussions/add-ons/">
 add-ons section</a> of our support site.
 
 <p>Debug info:</p>
-""")        
+""")
         if self.mw.addonManager.dirty:
             txt = pluginText
             error = supportText() + self._addonText(error) + "\n" + error
         else:
             txt = stdText
             error = supportText() + "\n" + error
-        
+
         # show dialog
         txt = txt + "<div style='white-space: pre-wrap'>" + error + "</div>"
         showText(txt, type="html", copyBtn=True)
@@ -142,7 +151,7 @@ add-ons section</a> of our support site.
         if not matches:
             return ""
         # reverse to list most likely suspect first, dict to deduplicate:
-        addons = [mw.addonManager.addonName(i) for i in
+        addons = [aqt_mw.addonManager.addonName(i) for i in
                   dict.fromkeys(reversed(matches))]
         txt = _("""Add-ons possibly involved: {}\n""")
         # highlight importance of first add-on:

--- a/aqt/exporting.py
+++ b/aqt/exporting.py
@@ -3,15 +3,23 @@
 
 import os
 import re
+import time
 
-from aqt.qt import *
-import  aqt
-from aqt.utils import getSaveFile, tooltip, showWarning, \
-    checkInvalidFilename, showInfo
 from anki.exporting import exporters
 from anki.hooks import addHook, remHook
 from anki.lang import ngettext, _
-import time
+
+import aqt.forms
+
+from aqt.qt import QDialog, QPushButton, QDialogButtonBox, Qt
+from aqt.utils import (
+    getSaveFile,
+    tooltip,
+    showWarning,
+    checkInvalidFilename,
+    showInfo
+)
+
 
 class ExportDialog(QDialog):
 

--- a/aqt/fields.py
+++ b/aqt/fields.py
@@ -1,11 +1,13 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-from aqt.qt import *
-from anki.consts import *
-import aqt
-from aqt.utils import showWarning, openHelp, getOnlyText, askUser
 from anki.lang import _, ngettext
+
+import aqt
+
+from aqt.qt import QDialogButtonBox, QDialog, QFont
+from aqt.utils import showWarning, openHelp, getOnlyText, askUser
+
 
 class FieldDialog(QDialog):
 

--- a/aqt/importing.py
+++ b/aqt/importing.py
@@ -10,15 +10,38 @@ import json
 import unicodedata
 import shutil
 
-from aqt.qt import *
 import anki.importing as importing
-from aqt.utils import getOnlyText, getFile, showText, showWarning, openHelp, \
-    askUser, tooltip, showInfo
 from anki.hooks import addHook, remHook
+from anki.lang import ngettext, _
+
 import aqt.forms
 import aqt.modelchooser
 import aqt.deckchooser
-from anki.lang import ngettext, _
+
+from aqt.qt import (
+    QDialog,
+    QDialogButtonBox,
+    QFrame,
+    QGridLayout,
+    QLabel,
+    QListWidgetItem,
+    QMessageBox,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+    Qt,
+)
+from aqt.utils import (
+    askUser,
+    getFile,
+    getOnlyText,
+    openHelp,
+    showInfo,
+    showText,
+    showWarning,
+    tooltip,
+)
+
 
 class ChangeMap(QDialog):
     def __init__(self, mw, model, current):

--- a/aqt/main.py
+++ b/aqt/main.py
@@ -2,22 +2,21 @@
 # -*- coding: utf-8 -*-
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
+import faulthandler
+import gc
+import os
+import platform
+import pprint
 import re
 import signal
-import zipfile
-import gc
+import sys
 import time
-import faulthandler
-import platform
-from threading import Thread
+import traceback
+import zipfile
 
 from send2trash import send2trash
-from aqt.qt import *
-from anki import Collection
-from anki.utils import  isWin, isMac, intTime, splitFields, ids2str, \
-        devMode
-from anki.hooks import runHook, addHook, runFilter
-import aqt
+from threading import Thread
+
 import aqt.progress
 import aqt.webview
 import aqt.toolbar
@@ -25,11 +24,54 @@ import aqt.stats
 import aqt.mediasrv
 import anki.sound
 import anki.mpv
-from aqt.utils import saveGeom, restoreGeom, showInfo, showWarning, \
-    restoreState, getOnlyText, askUser, showText, tooltip, \
-    openHelp, openLink, checkInvalidFilename, getFile
-from aqt.qt import sip
+
+from anki import Collection
+from anki.hooks import runHook, addHook, runFilter
 from anki.lang import _, ngettext
+from anki.utils import (
+    isWin,
+    isMac,
+    intTime,
+    splitFields,
+    ids2str,
+    devMode,
+)
+
+from aqt.qt import (
+    QAction,
+    QDialog,
+    QDialogButtonBox,
+    QFontDatabase,
+    QKeySequence,
+    QMainWindow,
+    QMessageBox,
+    QPushButton,
+    QShortcut,
+    QTextCursor,
+    QTextEdit,
+    QThread,
+    QVBoxLayout,
+    Qt,
+    pyqtSignal,
+    qtminor,
+    sip,
+)
+from aqt.utils import (
+    askUser,
+    checkInvalidFilename,
+    getFile,
+    getOnlyText,
+    openHelp,
+    openLink,
+    restoreGeom,
+    restoreState,
+    saveGeom,
+    showInfo,
+    showText,
+    showWarning,
+    tooltip,
+)
+
 
 class AnkiQt(QMainWindow):
     def __init__(self, app, profileManager, opts, args):
@@ -1247,7 +1289,6 @@ will be lost. Continue?"""))
         self.onDebugRet(frm)
 
     def onDebugRet(self, frm):
-        import pprint, traceback
         text = frm.text.toPlainText()
         card = self._debugCard
         bcard = self._debugBrowserCard

--- a/aqt/mediasrv.py
+++ b/aqt/mediasrv.py
@@ -2,14 +2,17 @@
 # -*- coding: utf-8 -*-
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-from aqt.qt import *
-from http import HTTPStatus
 import http.server
-import socketserver
+import os
 import socket
-from anki.utils import devMode
+import socketserver
 import threading
 import re
+
+from http import HTTPStatus
+
+from anki.utils import devMode, isMac
+
 
 # locate web folder in source/binary distribution
 def _getExportFolder():

--- a/aqt/modelchooser.py
+++ b/aqt/modelchooser.py
@@ -2,10 +2,19 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-from aqt.qt import *
 from anki.hooks import addHook, remHook, runHook
-from aqt.utils import  shortcut
 from anki.lang import _
+
+from aqt.qt import (
+    QHBoxLayout,
+    QKeySequence,
+    QLabel,
+    QPushButton,
+    QShortcut,
+    QSizePolicy,
+)
+from aqt.utils import shortcut
+
 
 class ModelChooser(QHBoxLayout):
 

--- a/aqt/models.py
+++ b/aqt/models.py
@@ -1,14 +1,35 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-from aqt.qt import *
-from operator import itemgetter
-from aqt.utils import showInfo, askUser, getText, maybeHideClose, openHelp
-import aqt.clayout
-from anki import stdmodels
-from aqt.utils import saveGeom, restoreGeom
 import collections
+
+from operator import itemgetter
+
+from anki import stdmodels
 from anki.lang import _, ngettext
+
+import aqt.modelchooser
+import aqt.clayout
+
+from aqt.qt import (
+    QDialog,
+    QDialogButtonBox,
+    QKeySequence,
+    QListWidgetItem,
+    QShortcut,
+    Qt,
+)
+
+from aqt.utils import (
+    askUser,
+    getText,
+    maybeHideClose,
+    openHelp,
+    restoreGeom,
+    saveGeom,
+    showInfo,
+)
+
 
 class Models(QDialog):
     def __init__(self, mw, parent=None, fromMain=False):

--- a/aqt/overview.py
+++ b/aqt/overview.py
@@ -2,10 +2,13 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-from aqt.utils import openLink, shortcut, tooltip, askUserDialog
-import aqt
-from anki.sound import clearAudioQueue
 from anki.lang import _
+from anki.sound import clearAudioQueue
+
+import aqt.forms
+
+from aqt.utils import openLink, shortcut, tooltip, askUserDialog
+
 
 class Overview:
     "Deck overview."

--- a/aqt/pinnedmodules.py
+++ b/aqt/pinnedmodules.py
@@ -7,16 +7,16 @@
 # pylint: disable=import-error,unused-import
 
 # required by requests library
-import queue
+import queue  # noqa
 
 from anki.utils import isWin
 
+# included implicitly in the past, and relied upon by some add-ons
+import cgi  # noqa
+import uuid  # noqa
+
 # external module access in Windows
 if isWin:
-    import pythoncom
-    import win32com
-    import pywintypes
-
-# included implicitly in the past, and relied upon by some add-ons
-import cgi
-import uuid
+    import pythoncom  # noqa
+    import win32com  # noqa
+    import pywintypes  # noqa

--- a/aqt/preferences.py
+++ b/aqt/preferences.py
@@ -2,12 +2,26 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-import datetime, time
-from aqt.qt import *
-import anki.lang
-from aqt.utils import openFolder, openHelp, showInfo, askUser
-import aqt
-from anki.lang import _
+import datetime
+import time
+
+from anki.lang import _, langs, getLang
+from anki.utils import isMac
+
+import aqt.forms
+
+from aqt.qt import (
+    QDialog,
+    QDialogButtonBox,
+    Qt,
+)
+from aqt.utils import (
+    askUser,
+    openFolder,
+    openHelp,
+    showInfo,
+)
+
 
 class Preferences(QDialog):
 
@@ -52,19 +66,19 @@ class Preferences(QDialog):
 
     def setupLang(self):
         f = self.form
-        f.lang.addItems([x[0] for x in anki.lang.langs])
+        f.lang.addItems([x[0] for x in langs])
         f.lang.setCurrentIndex(self.langIdx())
         f.lang.currentIndexChanged.connect(self.onLangIdxChanged)
 
     def langIdx(self):
-        codes = [x[1] for x in anki.lang.langs]
+        codes = [x[1] for x in langs]
         try:
-            return codes.index(anki.lang.getLang())
-        except:
+            return codes.index(getLang())
+        except Exception:
             return codes.index("en")
 
     def onLangIdxChanged(self, idx):
-        code = anki.lang.langs[idx][1]
+        code = langs[idx][1]
         self.mw.pm.setLang(code)
         showInfo(_("Please restart Anki to complete language change."), parent=self)
 
@@ -228,4 +242,3 @@ Not currently enabled; click the sync button in the main window to enable."""))
 
     def updateOptions(self):
         self.prof['pastePNG'] = self.form.pastePNG.isChecked()
-

--- a/aqt/profiles.py
+++ b/aqt/profiles.py
@@ -6,23 +6,32 @@
 # - Saves in pickles rather than json to easily store Qt window state.
 # - Saves in sqlite rather than a flat file so the config can't be corrupted
 
-import random
-import pickle
-import shutil
 import io
 import locale
+import os
+import pickle
+import random
 import re
+import shutil
+import sys
 
-from aqt.qt import *
-from anki.db import DB
-from anki.utils import isMac, isWin, intTime
-import anki.lang
-from aqt.utils import showWarning
-from aqt import appHelpSite
-import aqt.forms
 from send2trash import send2trash
+
 import anki.sound
-from anki.lang import _
+
+from anki.db import DB
+from anki.lang import _, langs, setLang
+from anki.utils import isMac, isWin, intTime
+
+import aqt.forms
+
+from aqt import appHelpSite
+from aqt.qt import (
+    QByteArray,
+    QDialog,
+    QMessageBox,
+)
+from aqt.utils import showWarning
 
 metaConf = dict(
     ver=0,
@@ -59,6 +68,7 @@ profileConf = dict(
     allowHTML=False,
     importMode=1,
 )
+
 
 class ProfileManager:
 
@@ -141,7 +151,7 @@ a flash drive.""" % self.base)
             def find_class(self, module, name):
                 if module == "PyQt5.sip":
                     try:
-                        import PyQt5.sip # pylint: disable=unused-import
+                        import PyQt5.sip # noqa pylint: disable=unused-import,import-error,no-name-in-module
                     except:
                         # use old sip location
                         module = "sip"
@@ -381,7 +391,7 @@ please see:
         # find index
         idx = None
         en = None
-        for c, (name, code) in enumerate(anki.lang.langs):
+        for c, (name, code) in enumerate(langs):
             if code == "en":
                 en = c
             if code == lang:
@@ -390,13 +400,13 @@ please see:
         if idx is None:
             idx = en
         # update list
-        f.lang.addItems([x[0] for x in anki.lang.langs])
+        f.lang.addItems([x[0] for x in langs])
         f.lang.setCurrentRow(idx)
         d.exec_()
 
     def _onLangSelected(self):
         f = self.langForm
-        obj = anki.lang.langs[f.lang.currentRow()]
+        obj = langs[f.lang.currentRow()]
         code = obj[1]
         name = obj[0]
         en = "Are you sure you wish to display Anki's interface in %s?"
@@ -412,7 +422,7 @@ please see:
         sql = "update profiles set data = ? where name = ?"
         self.db.execute(sql, self._pickle(self.meta), "_global")
         self.db.commit()
-        anki.lang.setLang(code, local=False)
+        setLang(code, local=False)
 
     # OpenGL
     ######################################################################

--- a/aqt/progress.py
+++ b/aqt/progress.py
@@ -3,9 +3,19 @@
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 import time
-from aqt.qt import *
-import aqt.forms
+
 from anki.lang import _
+
+import aqt.forms
+
+from aqt.qt import (
+    QApplication,
+    QCursor,
+    QDialog,
+    QEventLoop,
+    QTimer,
+    Qt,
+)
 
 # fixme: if mw->subwindow opens a progress dialog with mw as the parent, mw
 # gets raised on finish on compiz. perhaps we should be using the progress
@@ -13,6 +23,7 @@ from anki.lang import _
 
 # Progress info
 ##########################################################################
+
 
 class ProgressManager:
 

--- a/aqt/qt.py
+++ b/aqt/qt.py
@@ -5,36 +5,128 @@
 # pylint: disable=unused-import
 
 import os
+import sys
+
+from pdb import set_trace, pm
+from traceback import format_exception
+
+# Import these for use in other modules
+# Separate GUI Object from other objects
+from PyQt5.Qt import (  # noqa
+    PYQT_VERSION_STR,
+    QT_VERSION,
+    QT_VERSION_STR,
+    qInstallMessageHandler,
+)
+from PyQt5.Qt import (  # noqa pylint: disable=no-name-in-module
+    QAbstractItemView,
+    QAbstractTableModel,
+    QAction,
+    QApplication,
+    QBrush,
+    QByteArray,
+    QCheckBox,
+    QClipboard,
+    QColor,
+    QColorDialog,
+    QComboBox,
+    QCompleter,
+    QCoreApplication,
+    QCursor,
+    QDesktopServices,
+    QDialog,
+    QDialogButtonBox,
+    QDockWidget,
+    QEvent,
+    QEventLoop,
+    QFile,
+    QFileDialog,
+    QFont,
+    QFontDatabase,
+    QFrame,
+    QGridLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QHeaderView,
+    QIODevice,
+    QIcon,
+    QImage,
+    QItemDelegate,
+    QItemSelection,
+    QItemSelectionModel,
+    QKeySequence,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QListWidgetItem,
+    QLocalServer,
+    QLocalSocket,
+    QMainWindow,
+    QMenu,
+    QMessageBox,
+    QNativeGestureEvent,
+    QNetworkProxy,
+    QObject,
+    QOffscreenSurface,
+    QOpenGLContext,
+    QOpenGLVersionProfile,
+    QPalette,
+    QPixmap,
+    QPoint,
+    QPushButton,
+    QShortcut,
+    QSizePolicy,
+    QStandardPaths,
+    QStringListModel,
+    QTextBrowser,
+    QTextCursor,
+    QTextEdit,
+    QThread,
+    QTimer,
+    QTranslator,
+    QTreeWidget,
+    QTreeWidgetItem,
+    QUrl,
+    QVBoxLayout,
+    QWebChannel,
+    QWidget,
+    QSize,
+    Qt,
+)
+from PyQt5.QtCore import (  # noqa pylint: disable=no-name-in-module
+    pyqtRemoveInputHook,
+    pyqtSignal,
+    pyqtSlot,
+)
+
+try:
+    from PyQt5 import sip  # noqa pylint: disable=no-name-in-module
+except ImportError:
+    import sip  # noqa pylint: disable=no-name-in-module
+
+# trigger explicit message in case of missing libraries
+# instead of silently failing to import
+from PyQt5.QtWebEngineWidgets import (  # noqa pylint: disable=no-name-in-module
+    QWebEnginePage,
+    QWebEngineProfile,
+    QWebEngineScript,
+    QWebEngineView,
+)
 
 # fix buggy ubuntu12.04 display of language selector
 os.environ["LIBOVERLAY_SCROLLBAR"] = "0"
 
-from anki.utils import isWin, isMac
-
-from PyQt5.Qt import *
-# trigger explicit message in case of missing libraries
-# instead of silently failing to import
-from PyQt5.QtWebEngineWidgets import *
-try:
-    from PyQt5 import sip
-except ImportError:
-    import sip
-
-from PyQt5.QtCore import pyqtRemoveInputHook # pylint: disable=no-name-in-module
 
 def debug():
-    from pdb import set_trace
     pyqtRemoveInputHook()
     set_trace()
 
-import sys, traceback
 
 if os.environ.get("DEBUG"):
     def info(type, value, tb):
-        for line in traceback.format_exception(type, value, tb):
+        for line in format_exception(type, value, tb):
             sys.stdout.write(line)
         pyqtRemoveInputHook()
-        from pdb import pm
         pm()
     sys.excepthook = info
 

--- a/aqt/reviewer.py
+++ b/aqt/reviewer.py
@@ -3,21 +3,34 @@
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 import difflib
-import re
 import html
-import unicodedata as ucd
 import html.parser
 import json
+import re
+import unicodedata as ucd
 
-from anki.lang import _, ngettext
-from aqt.qt import *
-from anki.utils import stripHTML, bodyClass
 from anki.hooks import addHook, runHook, runFilter
+from anki.lang import _, ngettext
 from anki.sound import playFromText, clearAudioQueue, play
-from aqt.utils import mungeQA, tooltip, askUserDialog, \
-    downArrow, qtMenuShortcutWorkaround
+from anki.utils import stripHTML, bodyClass
+
+import aqt.forms
+
+from aqt.qt import (
+    QCursor,
+    QKeySequence,
+    QMenu,
+    QMessageBox,
+    Qt,
+)
 from aqt.sound import getAudio
-import aqt
+from aqt.utils import (
+    askUserDialog,
+    downArrow,
+    mungeQA,
+    qtMenuShortcutWorkaround,
+    tooltip,
+)
 
 
 class Reviewer:

--- a/aqt/sound.py
+++ b/aqt/sound.py
@@ -1,15 +1,17 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-from aqt.qt import *
-
 import time
-from anki.sound import Recorder
-from aqt.utils import saveGeom, restoreGeom, showWarning
+
 from anki.lang import _
+from anki.sound import Recorder
+
+from aqt.qt import QPushButton, QMessageBox, QApplication, QPixmap
+from aqt.utils import saveGeom, restoreGeom, showWarning
 
 if not Recorder:
     print("pyaudio not installed")
+
 
 def getAudio(parent, encode=True):
     "Record and return filename"

--- a/aqt/stats.py
+++ b/aqt/stats.py
@@ -2,15 +2,25 @@
 # -*- coding: utf-8 -*-
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-from aqt.qt import *
-import os, time
-from aqt.utils import saveGeom, restoreGeom, maybeHideClose, addCloseShortcut, \
-    tooltip, getSaveFile
-import aqt
+import time
+
 from anki.lang import _
+
+import aqt.forms
+
+from aqt.qt import Qt, QDialogButtonBox, QDialog
+from aqt.utils import (
+    addCloseShortcut,
+    getSaveFile,
+    maybeHideClose,
+    restoreGeom,
+    saveGeom,
+    tooltip,
+)
 
 # Deck Stats
 ######################################################################
+
 
 class DeckStats(QDialog):
 

--- a/aqt/studydeck.py
+++ b/aqt/studydeck.py
@@ -2,11 +2,22 @@
 # -*- coding: utf-8 -*-
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-from aqt.qt import *
-import aqt
-from aqt.utils import showInfo, openHelp, getOnlyText, shortcut, restoreGeom, saveGeom
-from anki.hooks import addHook, remHook
 from anki.lang import _
+from anki.hooks import addHook, remHook
+
+import aqt
+
+from aqt.qt import (
+    QAbstractItemView,
+    QDialog,
+    QDialogButtonBox,
+    QEvent,
+    QKeySequence,
+    QPushButton,
+    Qt,
+)
+from aqt.utils import showInfo, openHelp, getOnlyText, shortcut, restoreGeom, saveGeom
+
 
 class StudyDeck(QDialog):
     def __init__(self, mw, names=None, accept=None, title=None,

--- a/aqt/sync.py
+++ b/aqt/sync.py
@@ -1,19 +1,38 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-import time
 import gc
+import time
+import traceback
 
-from aqt.qt import *
 from anki import Collection
-from anki.sync import Syncer, RemoteServer, FullSyncer, MediaSyncer, \
-    RemoteMediaServer
 from anki.hooks import addHook, remHook
-from aqt.utils import tooltip, askUserDialog, showWarning, showText, showInfo
 from anki.lang import _
+from anki.sync import (
+    FullSyncer,
+    MediaSyncer,
+    RemoteMediaServer,
+    RemoteServer,
+    Syncer,
+)
+
+from aqt.qt import (
+    QDialog,
+    QDialogButtonBox,
+    QGridLayout,
+    QLabel,
+    QLineEdit,
+    QObject,
+    QThread,
+    QVBoxLayout,
+    Qt,
+    pyqtSignal,
+)
+from aqt.utils import tooltip, askUserDialog, showWarning, showText, showInfo
 
 # Sync manager
 ######################################################################
+
 
 class SyncManager(QObject):
 
@@ -460,5 +479,3 @@ class SyncThread(QThread):
 
     def fireEvent(self, cmd, arg=""):
         self.event.emit(cmd, arg)
-
-

--- a/aqt/tagedit.py
+++ b/aqt/tagedit.py
@@ -1,8 +1,18 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-from aqt.qt import *
 import re
+
+from aqt.qt import (
+    QCompleter,
+    QLineEdit,
+    QStringListModel,
+    QWidget,
+    Qt,
+    pyqtSignal,
+    sip,
+)
+
 
 class TagEdit(QLineEdit):
 

--- a/aqt/taglimit.py
+++ b/aqt/taglimit.py
@@ -2,8 +2,17 @@
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/copyleft/agpl.html
 
 import aqt
-from aqt.qt import *
+
+from aqt.qt import (
+    QDialog,
+    QItemSelectionModel,
+    QKeySequence,
+    QListWidgetItem,
+    QShortcut,
+    Qt,
+)
 from aqt.utils import saveGeom, restoreGeom
+
 
 class TagLimit(QDialog):
 

--- a/aqt/toolbar.py
+++ b/aqt/toolbar.py
@@ -2,8 +2,8 @@
 # -*- coding: utf-8 -*-
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-from aqt.qt import *
 from anki.lang import _
+
 
 class Toolbar:
 

--- a/aqt/update.py
+++ b/aqt/update.py
@@ -5,11 +5,14 @@ import time
 
 import requests
 
-from aqt.qt import *
-import aqt
-from aqt.utils import openLink, showText
 from anki.utils import platDesc, versionWithBuild
 from anki.lang import _
+
+import aqt.forms
+
+from aqt.qt import QThread, QMessageBox, QPushButton, pyqtSignal
+from aqt.utils import openLink, showText
+
 
 class LatestVersionFinder(QThread):
 

--- a/aqt/utils.py
+++ b/aqt/utils.py
@@ -2,13 +2,65 @@
 # -*- coding: utf-8 -*-
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-from aqt.qt import *
-import re, os, sys, subprocess
-import aqt
-from anki.sound import stripSounds
-from anki.utils import isWin, isMac, invalidFilename, noBundledLibs, \
-    versionWithBuild
+import os
+import re
+import subprocess
+import sys
+
+from contextlib import contextmanager
+
 from anki.lang import _
+from anki.sound import stripSounds
+from anki.utils import (
+    invalidFilename,
+    isMac,
+    isWin,
+    versionWithBuild,
+)
+
+import aqt.forms
+
+from aqt.qt import (
+    PYQT_VERSION_STR,
+    QAction,
+    QApplication,
+    QColor,
+    QDesktopServices,
+    QDialog,
+    QDialogButtonBox,
+    QFileDialog,
+    QFrame,
+    QKeySequence,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QMenu,
+    QMessageBox,
+    QOffscreenSurface,
+    QOpenGLContext,
+    QOpenGLVersionProfile,
+    QPalette,
+    QPoint,
+    QPushButton,
+    QShortcut,
+    QSize,
+    QStandardPaths,
+    QT_VERSION_STR,
+    QTextBrowser,
+    QUrl,
+    QVBoxLayout,
+    Qt,
+    qtminor,
+)
+
+
+@contextmanager
+def noBundledLibs():
+    oldlpath = os.environ.pop("LD_LIBRARY_PATH", None)
+    yield
+    if oldlpath is not None:
+        os.environ["LD_LIBRARY_PATH"] = oldlpath
+
 
 def openHelp(section):
     link = aqt.appHelpSite

--- a/aqt/webview.py
+++ b/aqt/webview.py
@@ -1,17 +1,46 @@
 # Copyright: Ankitects Pty Ltd and contributors
 # -*- coding: utf-8 -*-
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
 import json
-import sys
 import math
+import os
+import sys
+
 from anki.hooks import runHook
-from aqt.qt import *
-from aqt.utils import openLink, tooltip
-from anki.utils import isMac, isWin, isLin
 from anki.lang import _
+from anki.utils import isMac, isWin, isLin
+
+from aqt.qt import (
+    QApplication,
+    QColor,
+    QCursor,
+    QDialog,
+    QEvent,
+    QFile,
+    QIODevice,
+    QKeySequence,
+    QMainWindow,
+    QMenu,
+    QNativeGestureEvent,
+    QObject,
+    QPalette,
+    QShortcut,
+    QUrl,
+    QWebChannel,
+    QWebEnginePage,
+    QWebEngineProfile,
+    QWebEngineScript,
+    QWebEngineView,
+    Qt,
+    pyqtSlot,
+    sip,
+)
+from aqt.utils import openLink, tooltip
 
 # Page for debug messages
 ##########################################################################
+
 
 class AnkiWebPage(QWebEnginePage):
 

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 TOOLS="$(cd "`dirname "$0"`"; pwd)"
-pylint -j 0 --rcfile=$TOOLS/../.pylintrc -f colorized --extension-pkg-whitelist=PyQt5 $TOOLS/../anki $TOOLS/../aqt
+pylint --rcfile=$TOOLS/../.pylintrc $TOOLS/../anki $TOOLS/../aqt


### PR DESCRIPTION
I'm trying to help clean up the codebase to make it easier for automated tools like flake8 to keep quality high.  I will attempt to make any pull requests I do extremely specific to not introduce churn or mix concerns.

My first change is to directly and explicitly import everything (with the exception of aqt/qt.py) so that it's obvious where definitions come from an dos that mistakes of redefining imports don't occur.  I think I moved some constants to the constants file too.

I've built and run this directly on both macOS and Windows 10.

Let me know if there's anything else you'd like to see for this change.