### PR TITLE
Use jsonschema for add-on manifests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ pyaudio
 requests
 decorator
 markdown
+jsonschema
 psutil; sys_platform == "win32"
 distro; sys_platform != "win32" and sys_platform != "darwin"

--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -1,0 +1,69 @@
+import os.path
+from nose.tools import assert_equals
+from mock import MagicMock
+from tempfile import TemporaryDirectory
+from zipfile import ZipFile
+
+from aqt.addons import AddonManager
+
+
+def test_readMinimalManifest():
+    assertReadManifest(
+        '{"package": "yes", "name": "no"}',
+        {"package": "yes", "name": "no"}
+    )
+
+
+def test_readExtraKeys():
+    assertReadManifest(
+        '{"package": "a", "name": "b", "mod": 3, "conflicts": ["d", "e"]}',
+        {"package": "a", "name": "b", "mod": 3, "conflicts": ["d", "e"]}
+    )
+
+
+def test_invalidManifest():
+    assertReadManifest(
+        '{"one": 1}',
+        {}
+    )
+
+
+def test_invalidJson():
+    assertReadManifest(
+        'this is not a JSON dictionary',
+        {}
+    )
+
+
+def test_missingManifest():
+    assertReadManifest(
+        '{"package": "what", "name": "ever"}',
+        {},
+        nameInZip="not-manifest.bin"
+    )
+
+
+def test_ignoreExtraKeys():
+    assertReadManifest(
+        '{"package": "a", "name": "b", "game": "c"}',
+        {"package": "a", "name": "b"}
+    )
+
+
+def test_conflictsMustBeStrings():
+    assertReadManifest(
+        '{"package": "a", "name": "b", "conflicts": ["c", 4, {"d": "e"}]}',
+        {}
+    )
+
+
+def assertReadManifest(contents, expectedManifest, nameInZip="manifest.json"):
+    with TemporaryDirectory() as td:
+        zfn = os.path.join(td, "addon.zip")
+        with ZipFile(zfn, "w") as zfile:
+            zfile.writestr(nameInZip, contents)
+
+        adm = AddonManager(MagicMock())
+
+        with ZipFile(zfn, "r") as zfile:
+            assert_equals(adm.readManifestFile(zfile), expectedManifest)


### PR DESCRIPTION
Thank you for a wonderful piece of software.

I just wanted to contribute something, so I looked for a todo note in the code and implemented it. Functionally, this improves add-on schema validation slightly. I hope you'll find it useful.

I did my best to follow the contributing guidelines, but if I'm doing something wrong I'd appreciate a pointer.