### PR TITLE
Use Nose test classes to help make tests read like documentation

### DIFF
--- a/tests/test_cards.py
+++ b/tests/test_cards.py
@@ -2,22 +2,6 @@
 
 from tests.shared import getEmptyCol
 
-def test_delete():
-    deck = getEmptyCol()
-    f = deck.newNote()
-    f['Front'] = '1'
-    f['Back'] = '2'
-    deck.addNote(f)
-    cid = f.cards()[0].id
-    deck.reset()
-    deck.sched.answerCard(deck.sched.getCard(), 2)
-    deck.remCards([cid])
-    assert deck.cardCount() == 0
-    assert deck.noteCount() == 0
-    assert deck.db.scalar("select count() from notes") == 0
-    assert deck.db.scalar("select count() from cards") == 0
-    assert deck.db.scalar("select count() from graves") == 2
-
 def test_misc():
     d = getEmptyCol()
     f = d.newNote()

--- a/tests/test_cards.py
+++ b/tests/test_cards.py
@@ -2,26 +2,6 @@
 
 from tests.shared import getEmptyCol
 
-def test_previewCards():
-    deck = getEmptyCol()
-    f = deck.newNote()
-    f['Front'] = '1'
-    f['Back'] = '2'
-    # non-empty and active
-    cards = deck.previewCards(f, 0)
-    assert len(cards) == 1
-    assert cards[0].ord == 0
-    # all templates
-    cards = deck.previewCards(f, 2)
-    assert len(cards) == 1
-    # add the note, and test existing preview
-    deck.addNote(f)
-    cards = deck.previewCards(f, 1)
-    assert len(cards) == 1
-    assert cards[0].ord == 0
-    # make sure we haven't accidentally added cards to the db
-    assert deck.cardCount() == 1
-
 def test_delete():
     deck = getEmptyCol()
     f = deck.newNote()

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -9,6 +9,51 @@ from anki import Collection as aopen
 newPath = None
 newMod = None
 
+
+class TestCollection:
+    def setup(self):
+        """Set up the System Under Test (SUT)."""
+        self.sut = getEmptyCol()
+
+    def teardown(self):
+        pass
+
+    def createSampleNote(self):
+        """Create a sample note to use in the tests."""
+        note = self.sut.newNote()
+        note['Front'] = '1'
+        note['Back'] = '2'
+        return note
+
+    def test_previewCards_WhenPreviewingInAddDialog(self):
+        note = self.createSampleNote()
+        preview_type = 0
+
+        cards = self.sut.previewCards(note, preview_type)
+
+        assert len(cards) == 1
+        assert cards[0].ord == 0
+
+    def test_previewCards_WhenPreviewingInEditDialog(self):
+        note = self.createSampleNote()
+        preview_type = 1
+
+        self.sut.addNote(note)
+        cards = self.sut.previewCards(note, preview_type)
+
+        assert len(cards) == 1
+        assert cards[0].ord == 0
+        assert self.sut.cardCount() == 1
+
+    def test_previewCards_WhenPreviewingInModelsDialog(self):
+        note = self.createSampleNote()
+        preview_type = 2
+
+        cards = self.sut.previewCards(note, preview_type)
+
+        assert len(cards) == 1
+
+
 def test_create_open():
     global newPath, newMod
     (fd, path) = tempfile.mkstemp(suffix=".anki2", prefix="test_attachNew")

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -53,6 +53,23 @@ class TestCollection:
 
         assert len(cards) == 1
 
+    def test_remCards_ShouldDeleteCardAndNote(self):
+        note = self.createSampleNote()
+        self.sut.addNote(note)
+        next_card = self.sut.sched.getCard()
+        recall_score = 2
+        card_id = note.cards()[0].id
+
+        self.sut.reset()
+        self.sut.sched.answerCard(next_card, recall_score)
+        self.sut.remCards([card_id])
+
+        assert self.sut.cardCount() == 0
+        assert self.sut.noteCount() == 0
+        assert self.sut.db.scalar("select count() from notes") == 0
+        assert self.sut.db.scalar("select count() from cards") == 0
+        assert self.sut.db.scalar("select count() from graves") == 2
+
 
 def test_create_open():
     global newPath, newMod


### PR DESCRIPTION
Documentation is imperative for the understanding of any codebase, and tests can sometimes serve as a good foundation for learning how things work together. The existing set of tests is great for catching regressions, and I think we can further spruce things up.

I moved a few tests related to the `Collection` class into a new `TestCollection` class in `test_collections.py`. This begins the process of centralizing tests that relate to that class, and also allows us to use `setup()` and `teardown()` for common test steps. Then, I began to split tests based on the comments already made in the test cases, and further organized the body of each test into the Arrange-Act-Assert pattern.

This is only a partial contribution, as I'm curious to know whether or not others would find this useful.