### PR TITLE
Schedv2 fill new by due

### DIFF
--- a/tests/test_schedv2.py
+++ b/tests/test_schedv2.py
@@ -1009,10 +1009,14 @@ def test_deckFlow():
     f['Front'] = "three"
     default1 = f.model()['did'] = d.decks.id("Default::1")
     d.addNote(f)
-    # should get top level one first, then ::1, then ::2
+    # add another with default deck
+    f = d.newNote()
+    f['Front'] = "four"
+    d.addNote(f)
+    # should get in order added
     d.reset()
-    assert d.sched.counts() == (3,0,0)
-    for i in "one", "three", "two":
+    assert d.sched.counts() == (4,0,0)
+    for i in "one", "two", "three", "four":
         c = d.sched.getCard()
         assert c.note()['Front'] == i
         d.sched.answerCard(c, 3)


### PR DESCRIPTION
In line with the the experimental v2 scheduler changes for reviews of decks with children, "When a deck has children, reviews are taken from all children decks at once, instead of showing each deck's review cards one by one.", this change shows new cards in order of their position (due) from all children decks at once.

The first reason is that it is more consistent with the review behaviour. The second, and more important, reason is it makes it possible to be able to reposition cards in the order you want to learn them without the old one by one scheduling of children decks overriding that.