### PR TITLE
Show new cards from children decks in order of card position

### DIFF
--- a/anki/collection.py
+++ b/anki/collection.py
@@ -47,6 +47,7 @@ defaultConf = {
     'sortBackwards': False,
     'addToCur': True, # add new to currently selected deck?
     'dayLearnFirst': False,
+    'fillNewByDue': False,
 }
 
 # this is initialized by storage.Collection

--- a/anki/schedv2.py
+++ b/anki/schedv2.py
@@ -389,11 +389,11 @@ did = ? and queue = 0 limit ?)""", did, lim)
                 lims[deck['name']] = lim = max(0, self.col.decks.confForDid(deck['id'])['new']['perDay'] - deck['newToday'][1])
             # adhere to parent limits
             name = deck['name']
-            parent = deck['name'].rsplit("::", 1)[0]
+            parent = name.rsplit("::", 1)[0]
             while parent != name:
                 name = parent
                 lim = min(lims[name], lim)
-                parent = deck['name'].rsplit("::", 1)[0]
+                parent = name.rsplit("::", 1)[0]
             # only select did with non-zero limits
             # to make sure if new count is non-zero
             # then at least one card is returned

--- a/anki/schedv2.py
+++ b/anki/schedv2.py
@@ -383,16 +383,20 @@ did = ? and queue = 0 limit ?)""", did, lim)
         # before children and lims[name] will exist
         for did in self._newDids:
             deck = self.col.decks.get(did)
-            if deck['dyn']:
-                lims[deck['name']] = lim = self.dynReportLimit
-            else:
-                lims[deck['name']] = lim = max(0, self.col.decks.confForDid(deck['id'])['new']['perDay'] - deck['newToday'][1])
-            # adhere to parent limits
             name = deck['name']
+            if deck['dyn']:
+                lims[name] = lim = self.dynReportLimit
+            else:
+                lims[name] = lim = max(0, self.col.decks.confForDid(deck['id'])['new']['perDay'] - deck['newToday'][1])
+            # adhere to parent limits
             parent = name.rsplit("::", 1)[0]
             while parent != name:
                 name = parent
-                lim = min(lims[name], lim)
+                if name in lims:
+                    lim = min(lims[name], lim)
+                else:
+                    # parent is not active
+                    break
                 parent = name.rsplit("::", 1)[0]
             # only select did with non-zero limits
             # to make sure if new count is non-zero

--- a/aqt/preferences.py
+++ b/aqt/preferences.py
@@ -86,8 +86,10 @@ class Preferences(QDialog):
         f.newSpread.setCurrentIndex(qc['newSpread'])
         f.useCurrent.setCurrentIndex(int(not qc.get("addToCur", True)))
         f.dayLearnFirst.setChecked(qc.get("dayLearnFirst", False))
+        f.fillNewByDue.setChecked(qc.get("fillNewByDue", False))
         if self.mw.col.schedVer() != 2:
             f.dayLearnFirst.setVisible(False)
+            f.fillNewByDue.setVisible(False)
         else:
             f.newSched.setChecked(True)
 
@@ -114,6 +116,7 @@ class Preferences(QDialog):
         qc['collapseTime'] = f.lrnCutoff.value()*60
         qc['addToCur'] = not f.useCurrent.currentIndex()
         qc['dayLearnFirst'] = f.dayLearnFirst.isChecked()
+        qc['fillNewByDue'] = f.fillNewByDue.isChecked()
         self._updateDayCutoff()
         self._updateSchedVer(f.newSched.isChecked())
         d.setMod()

--- a/designer/preferences.ui
+++ b/designer/preferences.ui
@@ -116,6 +116,13 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="fillNewByDue">
+         <property name="text">
+          <string>Show new cards from all children decks at once</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QComboBox" name="useCurrent">
          <item>
           <property name="text">
@@ -488,6 +495,7 @@
   <tabstop>nightMode</tabstop>
   <tabstop>dayLearnFirst</tabstop>
   <tabstop>newSched</tabstop>
+  <tabstop>fillNewByDue</tabstop>
   <tabstop>useCurrent</tabstop>
   <tabstop>newSpread</tabstop>
   <tabstop>dayOffset</tabstop>


### PR DESCRIPTION
Hi @Damien

Sorry to open this pull request ([https://github.com/dae/anki/pull/311](https://github.com/dae/anki/pull/311)) again and if you close it this time I won't do it again. Thank you for the feedback and the link to the discussion.

dae commented:
"This will break things for users who rely on the deck ordering, and slow big deck trees down. Please see https://anki.tenderapp.com/discussions/beta-testing/968-experimental-scheduler-in-anki-210beta31/page/1#comment_46896046"

I believe with this pull request I have addressed your two concerns:

1. Breaking the default for users who rely on it

I made this feature an option disabled by default than can be enabled in Preferences. It's only available for the experimental scheduler and the option is not displayed if the experimental scheduler is disabled.

2. Slowing big deck trees down

I created a mock deck with 2000 children decks of 1000 cards each to observe the performance and improved the code. The slowest part was actually the `order by ord` part of the SQLite query. My understanding is the `ord` (ordinal) attribute only identifies the card template so there should be no requirement to use it for ordering? Even after removing that, the database queries consumed the most time so I now only make 1 query and then filter the result to fit the children's limits. Cards being dropped due to deck limits means the new queue will only partially fill and must be completed in subsequent calls when the new queue becomes empty.

Now `_deckNewLimit` is always called for every child deck it's inefficiency is apparent. This is largely because of `self.col.decks.parents(did)` calling the `id` method of `DeckManager`. Replacing `parents` with `parentsByName` resulted in a factor of 3 speed up. 

With 2000 children decks of 1000 cards each and 9999 new/day the time to fill the new queue was 70 ms with my i5-6300U processor. Not even noticeable. But with a deck size of 2 million cards other parts of the interface not related to the new queue start showing considerable lag. Opening the browser takes _seconds_ to open up, as does returning to the main window/deck browser from reviewing.

I hope you'll give this request another look.

Lewis