### PR TITLE
Remove outdated pyqt mentions from README.development

### DIFF
--- a/README.development
+++ b/README.development
@@ -108,8 +108,5 @@ installed. Most likely you will need to have installed xcode
 Install homebrew (http://brew.sh/) and then install Anki prerequisites:
 
 $ brew install python mplayer lame portaudio
-$ pip install sqlalchemy pyqt5==5.9.2
-
-Make sure to specify pyqt5 version 5.9.2, as the latest version 5.10 is not currently supported.
 
 Now you can follow the development commands at the start of this document.


### PR DESCRIPTION
Hi Damien! Thanks again for the great work! I happen to develop some Anki add-ons on my Mac. The instructions for Mac section were helpful when I started, but that line should be lifted now since Anki supports fresher versions of PyQT 5.9.x (last week I updated PyQt to 5.13.0 and everything seems to work fine). And the instructions at the beginning of the document help to install the latest version. 