### PR TITLE
Show the correct window icon when running on Wayland

### DIFF
--- a/aqt/__init__.py
+++ b/aqt/__init__.py
@@ -312,6 +312,7 @@ def _run(argv=None, exec=True):
     # create the app
     app = AnkiApp(argv)
     QCoreApplication.setApplicationName("Anki")
+    QGuiApplication.setDesktopFileName("anki.desktop")
     if app.secondInstance():
         # we've signaled the primary instance, so we should close
         return


### PR DESCRIPTION
This change lets Anki find the right desktop file when it runs under Wayland. Without the change it will look for python3.desktop. The important thing, for me at least, is that this will run Anki with app_id 'anki' instead of 'python3'. That gives me the possibility to automatically start Anki with some specific configuration.