### PR TITLE
Allow configuring Anki's color scheme using a single config file on Linux

### DIFF
--- a/aqt/__init__.py
+++ b/aqt/__init__.py
@@ -310,9 +310,9 @@ def _run(argv=None, exec=True):
         QCoreApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
 
     # create the app
-    app = AnkiApp(argv)
     QCoreApplication.setApplicationName("Anki")
     QGuiApplication.setDesktopFileName("anki.desktop")
+    app = AnkiApp(argv)
     if app.secondInstance():
         # we've signaled the primary instance, so we should close
         return


### PR DESCRIPTION
Hi,

I had some problems configuring Anki to use a light color scheme instead of the dark one that I use by default. It would only use the light colors for a part of the UI. It turned out the problem was Anki was loading configuration from both ~/.config/ankirc and ~/.config/Ankirc. This change fixes that by setting the application name, which is used to determine the config file name, before instantiating the application.

Cheers,
Wilco