### PR TITLE
Allow disabling timeTicks

### DIFF
--- a/anki/stats.py
+++ b/anki/stats.py
@@ -811,7 +811,10 @@ from cards where did in %s""" % self._limit())
         conf['yaxis']['labelWidth'] = 40
         if 'xaxis' not in conf:
             conf['xaxis'] = {}
-        conf['timeTicks'] = {1: _("d"), 7: _("w"), 31: _("mo")}[xunit]
+        if xunit is None:
+            conf['timeTicks'] = False
+        else:
+            conf['timeTicks'] = {1: _("d"), 7: _("w"), 31: _("mo")}[xunit]
         # types
         width = self.width
         height = self.height


### PR DESCRIPTION
You used to be able to specify `timeTicks=False` to disable labels on the  x-axis of a graph. In fact, the if condition that provides this feature is still present in the code [here](https://github.com/dae/anki/blob/039f6bb382f5d10ea5a30eb1d64df3b9937d75d1/anki/stats.py#L867).

However, in #290 this feature was removed [here](https://github.com/dae/anki/pull/290/files/08e51f220fc36467c5b4748e3f6005049afd7443#diff-0034f10fd87b7ba129a5b68317de9c50L828).

This PR offers one way to bring back this feature -- by allowing a new values  `None` for `xunit` to mean no automatic labels should be provided.

The other way we could provide this feature is by first checking if `timeTicks` is already present in `conf` before setting it (that way the addon can pass in the setting of their choice) but I'm not sure if you want this level of flexibility.