### PR TITLE
Add support for OpenGL software rendering.

### DIFF
--- a/aqt/__init__.py
+++ b/aqt/__init__.py
@@ -309,6 +309,10 @@ def _run(argv=None, exec=True):
     if not os.environ.get("ANKI_NOHIGHDPI"):
         QCoreApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
 
+    # Opt into software rendering. Useful for buggy systems.
+    if os.environ.get("ANKI_SOFTWAREOPENGL"):
+        QCoreApplication.setAttribute(Qt.AA_UseSoftwareOpenGL)
+
     # create the app
     QCoreApplication.setApplicationName("Anki")
     QGuiApplication.setDesktopFileName("anki.desktop")


### PR DESCRIPTION
For some reason, on my Mac, Anki fails to start - an empty window appears, and the logs show some sort of an issue with OpenGL([screenshot](https://user-images.githubusercontent.com/19738/63198855-5c634c80-c07c-11e9-9c63-f80fae68b05e.png)):

    [14376:775:0816/224908.097462:ERROR:gl_context_cgl.cc(123)] Error creating context.
    [14376:775:0816/224908.097490:ERROR:gpu_channel_manager.cc(383)] ContextResult::kFatalFailure: Failed to create shared context for virtualization.
    [14376:775:0816/224908.097496:ERROR:raster_command_buffer_stub.cc(99)] ContextResult::kFatalFailure: Failed to create raster decoder state.

I'm not the only one affected by this issue (in the wider Qt ecosystem, that is), but it does seem to be quite rare. The workaround is to force software rendering using Qt::AA_UseSoftwareOpenGL. This pull request adds support for a new environment variable, ANKI_SOFTWAREOPENGL, that will do just that.