### PR TITLE
Use traceback.format_exception for debug error display.

### DIFF
--- a/aqt/errors.py
+++ b/aqt/errors.py
@@ -12,9 +12,8 @@ from aqt import mw
 
 if not os.environ.get("DEBUG"):
     def excepthook(etype,val,tb):
-        sys.stderr.write("Caught exception:\n%s%s\n" % (
-            ''.join(traceback.format_tb(tb)),
-            '{0}: {1}'.format(etype, val)))
+        sys.stderr.write("Caught exception:\n%s\n" % (
+            ''.join(traceback.format_exception(etype, val, tb))))
     sys.excepthook = excepthook
 
 class ErrorHandler(QObject):


### PR DESCRIPTION
In Python 3, exceptions can be [chained](https://docs.python.org/3/reference/simple_stmts.html#the-raise-statement) using the `raise X from Y` syntax.

I find this feature very useful. In the add-on I'm writing, I've wrapped important parts of the code with a try-except for the sole purpose of adding additional context, like so:

```python
try:
    ...
except BaseException as e:
    raise AddonError({additional context}) from e
```

This makes tracebacks much more useful, as I can include contextual information, eg. about the card that caused the exception, and it all will be displayed in the traceback, alongside the actual error.

In order for this strategy to actually work, Anki needs to show chained exceptions. Right now this is not the case, as the debug error message is constructed manually using `traceback.format_tb`. Luckily, the entire thing can be replaced with [`traceback.format_exception`](https://docs.python.org/3/library/traceback.html#traceback.format_exception), which also shows chained exceptions.