### PR TITLE
Fix case sensitive field names

### DIFF
--- a/anki/find.py
+++ b/anki/find.py
@@ -530,28 +530,22 @@ def findReplace(col, nids, src, dst, regex=False, field=None, fold=True):
 
 def fieldNames(col, downcase=True):
     fields = set()
-    names = []
     for m in col.models.all():
         for f in m['flds']:
-            if f['name'].lower() not in fields:
-                names.append(f['name'])
-                fields.add(f['name'].lower())
-    if downcase:
-        return list(fields)
-    return names
+            name=f['name'].lower() if downcase else f['name']
+            if name not in fields: #slower w/o
+                fields.add(name)
+    return list(fields)
 
 def fieldNamesForNotes(col, nids):
-    downcasedNames = set()
-    origNames = []
+    fields = set()
     mids = col.db.list("select distinct mid from notes where id in %s" % ids2str(nids))
     for mid in mids:
         model = col.models.get(mid)
-        for field in col.models.fieldNames(model):
-            if field.lower() not in downcasedNames:
-                downcasedNames.add(field.lower())
-                origNames.append(field)
-
-    return sorted(origNames, key=lambda x: x.lower())
+        for name in col.models.fieldNames(model):
+            if name not in fields: #slower w/o
+                fields.add(name)
+    return sorted(list(fields), key=lambda x: x.lower())
 
 # Find duplicates
 ##########################################################################

--- a/anki/find.py
+++ b/anki/find.py
@@ -545,7 +545,7 @@ def fieldNamesForNotes(col, nids):
         for name in col.models.fieldNames(model):
             if name not in fields: #slower w/o
                 fields.add(name)
-    return sorted(list(fields), key=lambda x: x.lower())
+    return sorted(fields, key=lambda x: x.lower())
 
 # Find duplicates
 ##########################################################################


### PR DESCRIPTION
This fixes case sensitive field names so that 'apple' and 'Apple' both show up in drop down list when performing a search and replace or other such operations. Currently, with two models and the same field name, a user could unintentionally replace the wrong field due to mixed cases in the field name.