### PR TITLE
Prevent non-integer ivl when importing from Mnemosyne

### DIFF
--- a/anki/importing/mnemo.py
+++ b/anki/importing/mnemo.py
@@ -76,7 +76,7 @@ acq_reps+ret_reps, lapses, card_type_id from cards"""):
             c.lapses = row[7]
             # ivl is inferred in mnemosyne
             next, prev = row[3:5]
-            c.ivl = max(1, (next - prev)/86400)
+            c.ivl = max(1, (next - prev)//86400)
             # work out how long we've got left
             rem = int((next - time.time())/86400)
             c.due = self.col.sched.today+rem


### PR DESCRIPTION
A reddit user had a few issues when importing from Mnemosyne, one of which was non-integer values interpreted as "v2 scheduler bug". I assume that's the line where they originated.
https://www.reddit.com/r/Anki/comments/cxcv27/what_just_happened_cards_with_v2_scheduler_bug/