### PR TITLE
clears undo before changing schedulers

### DIFF
--- a/anki/collection.py
+++ b/anki/collection.py
@@ -110,6 +110,7 @@ class _Collection:
             raise Exception("Unsupported scheduler version")
 
         self.modSchema(check=True)
+        self.clearUndo()
 
         from anki.schedv2 import Scheduler
         v2Sched = Scheduler(self)


### PR DESCRIPTION
Accidentally using undo after switching between V1/V2 creates cards with invalid status (queue 3 type 3, queue -3 type 3, etc...) and also marks the database as V2 while triggering the V1 scheduler (3 buttons) or vice versa.