### PR TITLE
Add "typing" to pinned modules

### DIFF
--- a/aqt/pinnedmodules.py
+++ b/aqt/pinnedmodules.py
@@ -25,3 +25,4 @@ import uuid
 import logging
 import logging.handlers
 import logging.config
+import typing


### PR DESCRIPTION
Hey Damien,

This commit would add `typing` to the list of pinned modules which would allow add-on authors to make full use of Python's newly introduced type annotations. It would also improve the situation when packaging third-party libraries, as more and more packages on pypi are starting to use type hints.

Thanks for considering this!