### PR TITLE
when sorting by easiness, put new card separately

### DIFF
--- a/anki/find.py
+++ b/anki/find.py
@@ -228,7 +228,7 @@ select distinct(n.id) from cards c, notes n where c.nid=n.id and """+preds
             elif type == "cardDue":
                 sort = "c.type, c.due"
             elif type == "cardEase":
-                sort = "c.factor"
+                sort = "c.type == 0, c.factor"
             elif type == "cardLapses":
                 sort = "c.lapses"
             elif type == "cardIvl":


### PR DESCRIPTION
There is a small problem in the browser when you sort by easiness. The new cards are mixed with the cards with 250% of ease. It makes little sens when the browser is seen, since new cards have the information (new).
This change simply move new cards at the end of the list of cards, so that cards with an acutal ease number are together