### PR TITLE
Added length check on profile name

### DIFF
--- a/aqt/main.py
+++ b/aqt/main.py
@@ -193,6 +193,8 @@ class AnkiQt(QMainWindow):
         if name:
             if name in self.pm.profiles():
                 return showWarning(_("Name exists."))
+            if len(name) >= 255:
+                return showWarning(_("Name should be less than 256 characters!"))
             if not self.profileNameOk(name):
                 return
             self.pm.create(name)


### PR DESCRIPTION
This pull requests adds a check on profile name while creating new profile. Limit has been set to 255. This pull request is follow up for this [bug report](https://anki.tenderapp.com/discussions/beta-testing/1571-not-checking-length-of-username).

This fixes situation where user could provide too long name and when he tries to open it, would get a trace of python code telling that filename is too long. This shows warning when name is longer than 255 characters.