### PR TITLE
Fix parsing of furigana

### DIFF
--- a/anki/template/furigana.py
+++ b/anki/template/furigana.py
@@ -6,6 +6,9 @@
 import re
 from anki.hooks import addHook
 
+# Match kanji followed by hiragana in brackets first
+narrow = r'([\u4e00-\u9faf]*)\[(.*?)\]'
+# Run original wider matching regex second
 r = r' ?([^ >]+?)\[(.+?)\]'
 ruby = r'<ruby><rb>\1</rb><rt>\2</rt></ruby>'
 
@@ -15,6 +18,7 @@ def noSound(repl):
             # return without modification
             return match.group(0)
         else:
+            # OK to use original match here as working on matching portion only
             return re.sub(r, repl, match.group(0))
     return func
 
@@ -22,13 +26,19 @@ def _munge(s):
     return s.replace("&nbsp;", " ")
 
 def kanji(txt, *args):
-    return re.sub(r, noSound(r'\1'), _munge(txt))
+    repl = noSound(r'\1')
+    first = re.sub(narrow, repl, _munge(txt))
+    return re.sub(r, repl, first)
 
 def kana(txt, *args):
-    return re.sub(r, noSound(r'\2'), _munge(txt))
+    repl = noSound(r'\2')
+    first = re.sub(narrow, repl, _munge(txt))
+    return re.sub(r, repl, first)
 
 def furigana(txt, *args):
-    return re.sub(r, noSound(ruby), _munge(txt))
+    repl = noSound(ruby)
+    first = re.sub(narrow, repl, _munge(txt))
+    return re.sub(r, repl, first)
 
 def install():
     addHook('fmod_kanji', kanji)


### PR DESCRIPTION
Currently the regular expression used to parse furigana will swallow preceding text if spaces arn't used between words.

For example, if you had `今日、暗記[あんき]と言うアプリで勉強[べんきょう]した`.
`{{furigana:field}}` would give you:
<ruby><rb>今日、暗記</rb><rt>あんき</rt></ruby><ruby><rb>と言うアプリで勉強</rb><rt>べんきょう</rt></ruby>した
when you would expect:
今日、<ruby><rb>暗記</rb><rt>あんき</rt></ruby>と言うアプリで<ruby><rb>勉強</rb><rt>べんきょう</rt></ruby>した

and `{{kana:field}}` would give:
`あんきべんきょうした` instead of `今日、あんきと言うアプリでべんきょうした`

This pull request adds an extra substitution step using a narrower regular express, which only matches kanji followed by text in square brackets.

To avoid breaking ruby text for anyone who puts it behind hiragana (e.g. `食べる[た]`) or is using it for a different language, it still runs the original regex after the narrower one. If you're happy breaking this slightly weird use of furigana I can just straight swap the regex out (which I already do in an [addon](https://github.com/arichardsmith/anki-furigana))

Cheers!