### PR TITLE
Added file counts when deleting media

### DIFF
--- a/aqt/main.py
+++ b/aqt/main.py
@@ -1107,7 +1107,7 @@ will be lost. Continue?"""))
             if report:
                 report += "\n\n\n"
             report += _(
-                "In media folder but not used by any cards:")
+                str(len(unused)) + " files found in media folder not used by any cards:")
             report += "\n" + "\n".join(unused)
         if nohave:
             if report:
@@ -1159,11 +1159,11 @@ will be lost. Continue?"""))
                 now = time.time()
                 if now - lastProgress >= 0.3:
                     lastProgress = now
-                    label = _("Deleted %s files...") % (c+1)
+                    label = _("%d files remaining...") % (len(unused) - (c+1))
                     self.progress.update(label)
         finally:
             self.progress.finish()
-        tooltip(_("Deleted."))
+        tooltip(_("Deleted %d files.") % c)
         diag.close()
 
     def onStudyDeck(self):

--- a/aqt/main.py
+++ b/aqt/main.py
@@ -1104,10 +1104,11 @@ will be lost. Continue?"""))
         if warnings:
             report += "\n".join(warnings) + "\n"
         if unused:
+            numberOfUnusedFilesLabel = str(len(unused))
             if report:
                 report += "\n\n\n"
-            report += _(
-                str(len(unused)) + " files found in media folder not used by any cards:")
+            report += numberOfUnusedFilesLabel + " "
+            report += ngettext("file found in media folder not used by any cards:", "files found in media folder not used by any cards:", int(numberOfUnusedFilesLabel))
             report += "\n" + "\n".join(unused)
         if nohave:
             if report:
@@ -1158,12 +1159,14 @@ will be lost. Continue?"""))
 
                 now = time.time()
                 if now - lastProgress >= 0.3:
+                    numberOfRemainingFilesToBeDeleted = len(unused) - c
                     lastProgress = now
-                    label = _("%d files remaining...") % (len(unused) - (c+1))
+                    label = ngettext("%d file remaining...", "%d files remaining...", numberOfRemainingFilesToBeDeleted) % numberOfRemainingFilesToBeDeleted
                     self.progress.update(label)
         finally:
             self.progress.finish()
-        tooltip(_("Deleted %d files.") % c)
+        numberOfFilesDeleted = c + 1
+        tooltip(ngettext("Deleted %d file.", "Deleted %d files.", numberOfFilesDeleted) % numberOfFilesDeleted)
         diag.close()
 
     def onStudyDeck(self):

--- a/aqt/main.py
+++ b/aqt/main.py
@@ -1104,14 +1104,12 @@ will be lost. Continue?"""))
         if warnings:
             report += "\n".join(warnings) + "\n"
         if unused:
-            numberOfUnusedFilesLabel = str(len(unused))
+            numberOfUnusedFilesLabel = len(unused)
             if report:
                 report += "\n\n\n"
-            report += numberOfUnusedFilesLabel + " "
-            report += ngettext(
-                "file found in media folder not used by any cards:",
-                "files found in media folder not used by any cards:",
-                int(numberOfUnusedFilesLabel))
+            report += ngettext("%d file found in media folder not used by any cards:",
+                "%d files found in media folder not used by any cards:",
+                numberOfUnusedFilesLabel) % numberOfUnusedFilesLabel
             report += "\n" + "\n".join(unused)
         if nohave:
             if report:

--- a/aqt/main.py
+++ b/aqt/main.py
@@ -1108,7 +1108,10 @@ will be lost. Continue?"""))
             if report:
                 report += "\n\n\n"
             report += numberOfUnusedFilesLabel + " "
-            report += ngettext("file found in media folder not used by any cards:", "files found in media folder not used by any cards:", int(numberOfUnusedFilesLabel))
+            report += ngettext(
+                "file found in media folder not used by any cards:",
+                "files found in media folder not used by any cards:",
+                int(numberOfUnusedFilesLabel))
             report += "\n" + "\n".join(unused)
         if nohave:
             if report:
@@ -1161,12 +1164,16 @@ will be lost. Continue?"""))
                 if now - lastProgress >= 0.3:
                     numberOfRemainingFilesToBeDeleted = len(unused) - c
                     lastProgress = now
-                    label = ngettext("%d file remaining...", "%d files remaining...", numberOfRemainingFilesToBeDeleted) % numberOfRemainingFilesToBeDeleted
+                    label = ngettext("%d file remaining...",
+                    "%d files remaining...",
+                    numberOfRemainingFilesToBeDeleted) % numberOfRemainingFilesToBeDeleted
                     self.progress.update(label)
         finally:
             self.progress.finish()
         numberOfFilesDeleted = c + 1
-        tooltip(ngettext("Deleted %d file.", "Deleted %d files.", numberOfFilesDeleted) % numberOfFilesDeleted)
+        tooltip(ngettext("Deleted %d file.",
+        "Deleted %d files.",
+        numberOfFilesDeleted) % numberOfFilesDeleted)
         diag.close()
 
     def onStudyDeck(self):


### PR DESCRIPTION
- Added total file count at initial "unused files found" dialog
- When deleting files the progress label is updated to show how many files remain to be deleted
- Upon successful deletion, tooltip now tells how many files were deleted
I license these changes under the BSD license, but I'll also send out a PM with this detail as described in the contributing instructions.