### PR TITLE
New cards of existing note take due value of NEW siblings

### DIFF
--- a/anki/collection.py
+++ b/anki/collection.py
@@ -354,8 +354,8 @@ crt=?, mod=?, scm=?, dty=?, usn=?, ls=?, conf=?""",
         have = {}
         dids = {}
         dues = {}
-        for id, nid, ord, did, due, odue, odid in self.db.execute(
-            "select id, nid, ord, did, due, odue, odid from cards where nid in "+snids):
+        for id, nid, ord, did, due, odue, odid, type in self.db.execute(
+            "select id, nid, ord, did, due, odue, odid, type from cards where nid in "+snids):
             # existing cards
             if nid not in have:
                 have[nid] = {}
@@ -375,7 +375,8 @@ crt=?, mod=?, scm=?, dty=?, usn=?, ls=?, conf=?""",
             # save due
             if odid != 0:
                 due = odue
-            if nid not in dues:
+            if nid not in dues and type == 0:
+                # Add due to new card only if it's the due of a new sibling
                 dues[nid] = due
         # build cards for each note
         data = []


### PR DESCRIPTION
Here is a bug, how to reproduce it, and why this is a fix.

This is a way to create a new note with a due card extremly high
without any add-on, just with basic anki.

Bug
===
Create a note type with three fields One, Two, and Three and three card
type One, Two and Three such that each card is generated when the
field of the same name is filled.

Create a note with fields One and Two filled only. Review card One and
click on good. Card one should goes in learning mode. Fill the field
Three. In the browser, you'll see that card Two and Three are new, but
card Two and Three's due value are distinct. More precisely, the due
value of card Three is equal to the due value of card One; except that
in card One it's interpreted as a timestamp, while in card Three it's
interpreted as a position in the list of new card.

You'll remark by the way that the due of card Three is extremly high,
potentially more than 1000000; which may explain why so many
collection has this bug.

Fix
===
Only consider due value of new cards.