### PR TITLE
Creating new basic type without doing full sync

### DIFF
--- a/anki/stdmodels.py
+++ b/anki/stdmodels.py
@@ -10,7 +10,7 @@ models = []
 # Basic
 ##########################################################################
 
-def newBasicModel(col):
+def _newBasicModel(col):
     mm = col.models
     m = mm.new(_("Basic"))
     fm = mm.newField(_("Front"))
@@ -24,7 +24,7 @@ def newBasicModel(col):
     return m
 
 def addBasicModel(col):
-    m = newBasicModel(col)
+    m = _newBasicModel(col)
     col.models.add(m)
     return m
 
@@ -54,7 +54,7 @@ models.append((lambda: _("Basic (type in the answer)"), addBasicTypingModel))
 
 def addForwardReverse(col):
     mm = col.models
-    m = newBasicModel(col)
+    m = _newBasicModel(col)
     m['name'] = _("Basic (and reversed card)")
     t = mm.newTemplate(_("Card 2"))
     t['qfmt'] = "{{"+_("Back")+"}}"
@@ -70,7 +70,7 @@ models.append((lambda: _("Basic (and reversed card)"), addForwardReverse))
 
 def addForwardOptionalReverse(col):
     mm = col.models
-    m = newBasicModel(col)
+    m = _newBasicModel(col)
     m['name'] = _("Basic (optional reversed card)")
     av = _("Add Reverse")
     fm = mm.newField(av)

--- a/anki/stdmodels.py
+++ b/anki/stdmodels.py
@@ -10,7 +10,7 @@ models = []
 # Basic
 ##########################################################################
 
-def addBasicModel(col):
+def newBasicModel(col):
     mm = col.models
     m = mm.new(_("Basic"))
     fm = mm.newField(_("Front"))
@@ -21,7 +21,11 @@ def addBasicModel(col):
     t['qfmt'] = "{{"+_("Front")+"}}"
     t['afmt'] = "{{FrontSide}}\n\n<hr id=answer>\n\n"+"{{"+_("Back")+"}}"
     mm.addTemplate(m, t)
-    mm.add(m)
+    return m
+
+def addBasicModel(col):
+    m = newBasicModel(col)
+    col.models.add(m)
     return m
 
 models.append((lambda: _("Basic"), addBasicModel))
@@ -50,12 +54,13 @@ models.append((lambda: _("Basic (type in the answer)"), addBasicTypingModel))
 
 def addForwardReverse(col):
     mm = col.models
-    m = addBasicModel(col)
+    m = newBasicModel(col)
     m['name'] = _("Basic (and reversed card)")
     t = mm.newTemplate(_("Card 2"))
     t['qfmt'] = "{{"+_("Back")+"}}"
     t['afmt'] = "{{FrontSide}}\n\n<hr id=answer>\n\n"+"{{"+_("Front")+"}}"
     mm.addTemplate(m, t)
+    mm.add(m)
     return m
 
 models.append((lambda: _("Basic (and reversed card)"), addForwardReverse))
@@ -65,7 +70,7 @@ models.append((lambda: _("Basic (and reversed card)"), addForwardReverse))
 
 def addForwardOptionalReverse(col):
     mm = col.models
-    m = addBasicModel(col)
+    m = newBasicModel(col)
     m['name'] = _("Basic (optional reversed card)")
     av = _("Add Reverse")
     fm = mm.newField(av)
@@ -74,6 +79,7 @@ def addForwardOptionalReverse(col):
     t['qfmt'] = "{{#%s}}{{%s}}{{/%s}}" % (av, _("Back"), av)
     t['afmt'] = "{{FrontSide}}\n\n<hr id=answer>\n\n"+"{{"+_("Front")+"}}"
     mm.addTemplate(m, t)
+    mm.add(m)
     return m
 
 models.append((lambda: _("Basic (optional reversed card)"),


### PR DESCRIPTION
There is currently what I believe to be a small bug in anki. You can
clone a note type without doing a full sync, but you can't create
forwardReverse and forwardOptionalReverse note type without doing a
full sync. On the other hand you can clone, and even create any other
basic type without doing a full sync.

This commit simply wants to correct this.

The main trouble is that the method to create a copy of forwardReverse
and forwardOptionalReverse use a copy of the basic model, and add this
copy in the model manager BEFORE adding yet another template. This
commit corrects it by ensuring that the model is added only after all
templates are added, so that anki does not detect any change of a
template in the schema.

In order to do this, I created a method newBasicModel which creates
the basic model without adding it.

By the way, addBasicTypingModel could also use newBasicModel, and then
only change afmt. I didn't do it here because I believe that you want
the change to be minimal, and this correction would not add any
feature, only factorize the code.