### PR TITLE
Cancel in "adding note type" debugging

### DIFF
--- a/anki/models.py
+++ b/anki/models.py
@@ -174,10 +174,13 @@ select id from cards where nid in (select id from notes where mid = ?)""",
         self.save(m)
 
     def ensureNameUnique(self, m):
+        m['name'] = self.ensureNotAModelName(m['name'], m['id'])
+
+    def ensureNotAModelName(self, name, mid=None):
         for mcur in self.all():
-            if (mcur['name'] == m['name'] and mcur['id'] != m['id']):
-                m['name'] += "-" + checksum(str(time.time()))[:5]
-                break
+            if (mcur['name'] == name and mcur['id'] != mid):
+                return name + "-" + checksum(str(time.time()))[:5]
+        return name
 
     def update(self, m):
         "Add or update an existing model. Used for syncing and merging."
@@ -220,10 +223,10 @@ and notes.mid = ? and cards.ord = ?""", m['id'], ord)
     # Copying
     ##################################################
 
-    def copy(self, m):
+    def copy(self, m, name=None):
         "Copy, save and return."
         m2 = copy.deepcopy(m)
-        m2['name'] = _("%s copy") % m2['name']
+        m2['name'] = name or (_("%s copy") % m2['name'])
         self.add(m2)
         return m2
 

--- a/anki/stdmodels.py
+++ b/anki/stdmodels.py
@@ -10,9 +10,11 @@ models = []
 # Basic
 ##########################################################################
 
-def addBasicModel(col):
+def addBasicModel(col, name=None):
     mm = col.models
-    m = mm.new(_("Basic"))
+    if name is None:
+        name = _("Basic")
+    m = mm.new(name)
     fm = mm.newField(_("Front"))
     mm.addField(m, fm)
     fm = mm.newField(_("Back"))
@@ -29,9 +31,11 @@ models.append((lambda: _("Basic"), addBasicModel))
 # Basic w/ typing
 ##########################################################################
 
-def addBasicTypingModel(col):
+def addBasicTypingModel(col, name=None):
     mm = col.models
-    m = mm.new(_("Basic (type in the answer)"))
+    if name is None:
+        name = _("Basic (type in the answer)")
+    m = mm.new(name)
     fm = mm.newField(_("Front"))
     mm.addField(m, fm)
     fm = mm.newField(_("Back"))
@@ -48,9 +52,9 @@ models.append((lambda: _("Basic (type in the answer)"), addBasicTypingModel))
 # Forward & Reverse
 ##########################################################################
 
-def addForwardReverse(col):
+def addForwardReverse(col, name=None):
     mm = col.models
-    m = addBasicModel(col)
+    m = addBasicModel(col, name)
     m['name'] = _("Basic (and reversed card)")
     t = mm.newTemplate(_("Card 2"))
     t['qfmt'] = "{{"+_("Back")+"}}"
@@ -63,9 +67,9 @@ models.append((lambda: _("Basic (and reversed card)"), addForwardReverse))
 # Forward & Optional Reverse
 ##########################################################################
 
-def addForwardOptionalReverse(col):
+def addForwardOptionalReverse(col, name=None):
     mm = col.models
-    m = addBasicModel(col)
+    m = addBasicModel(col, name)
     m['name'] = _("Basic (optional reversed card)")
     av = _("Add Reverse")
     fm = mm.newField(av)
@@ -82,9 +86,11 @@ models.append((lambda: _("Basic (optional reversed card)"),
 # Cloze
 ##########################################################################
 
-def addClozeModel(col):
+def addClozeModel(col, name=None):
     mm = col.models
-    m = mm.new(_("Cloze"))
+    if name is None:
+        name = _("Cloze")
+    m = mm.new(name)
     m['type'] = MODEL_CLOZE
     txt = _("Text")
     fm = mm.newField(txt)


### PR DESCRIPTION
There is what I believe to be a bug in anki.
=====

* open the note type manager
* click on add
* Select anything
* click Ok
* click cancel

The expected result would be that the new note type is not added. The
obtained result is that the note type have the default
name. I.e. either old name followed by " copy". Or a name with five
random symbols at the end.

This commit simply ensure that, when the "cancel" button is clicked,
no note type is added.

Correction
=======
There are many way to do it. I did what I think to be the most elegant
way to do it.

The problem I faced that the default name, presented to the user, was
found in the model. However, the standard models does not necessarily
exists yet. And the methods which creates the standard models also add
them to the collection. Since I don't want to change those methods, my
solution was to find the name somewhere else.

That is why the parameter models in aqt.models.AddModel now contains an
list with three values. The third one being the name shown to the
user (unless this name is not unique).

This also means that I did move the request for a name to AddModel,
instead of having it in "onAdd". This ensure that AddModel does the
entire work of adding a model. onAdd simply ass AddModel to do all the
work, and potentially refresh the list.

In order to give the user a name which is unique without having to
create a model, I did split the method ensureNameUnique. It's main
body, i.e. computing a string which is not a name, is now in
ensureNotAModelName.

Since the name is now known when the model is created, I decided that
methods creating a new model can take a name as argument. Since those
methods add the model in the model manager, I believe that it's
elegant, since it allows to avoid having to save the deck a second
time later. Of course, the name is an optional argument, and the
effect is not changed when no name is given.