### PR TITLE
Do not ask confirmation for language interface

### DIFF
--- a/aqt/profiles.py
+++ b/aqt/profiles.py
@@ -396,13 +396,6 @@ please see:
         f = self.langForm
         obj = anki.lang.langs[f.lang.currentRow()]
         code = obj[1]
-        name = obj[0]
-        en = "Are you sure you wish to display Anki's interface in %s?"
-        r = QMessageBox.question(
-            None, "Anki", en%name, QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.No)
-        if r != QMessageBox.Yes:
-            return self._setDefaultLang()
         self.setLang(code)
 
     def setLang(self, code):


### PR DESCRIPTION
Hi,

Thanks for the software. A small contribution:

On the first run, a popup window appears asking in which language do
we wish to use Anki.
After language selection, a confirmation was asked.

This commit removes the confirmation as it does not bring much added
value while reducing the first impression (pop-up after the first user
choice is not very encouraging).

As explained [here](https://www.nngroup.com/articles/confirmation-dialog/), the confirmation dialogs are useful for action
with serious consequences such as actions that can not be undone.
Changing the language is still possible after the confirmation, this
is a rather standard feature and we can assume that a user that
selected the wrong language could figure out how to change the
language back (it is the first option in a standard "Preferences" menu
as many software do).

To talk about my personal experience, I was a bit surprised to get a dialogue on literally the second click I made and my first though was "I hope I won't get this too often". ;-)