### PR TITLE
Tells QT not to translate shortcuts.

### DIFF
--- a/anki/stats.py
+++ b/anki/stats.py
@@ -379,6 +379,7 @@ group by day order by day""" % (self._limit(), lim),
             tunit = _("hours")
         else:
             tunit = unit
+        #T: unit: can be hours, minutes, reviews... tot: the number of unit.
         self._line(i, _("Total"), _("%(tot)s %(unit)s") % dict(
             unit=tunit, tot=int(tot)))
         if convHours:
@@ -747,6 +748,7 @@ when you answer "good" on a review.''')
         return txt
 
     def _line(self, i, a, b, bold=True):
+        #T: Symbols separating first and second column in a statistics table. Eg in "Total:    3 reviews".
         colon = _(":")
         if bold:
             i.append(("<tr><td width=200 align=right>%s%s</td><td><b>%s</b></td></tr>") % (a,colon,b))
@@ -814,7 +816,13 @@ from cards where did in %s""" % self._limit())
         if xunit is None:
             conf['timeTicks'] = False
         else:
-            conf['timeTicks'] = {1: _("d"), 7: _("w"), 31: _("mo")}[xunit]
+            #T: abbreviation of day
+            d = _("d")
+            #T: abbreviation of week
+            w = _("w")
+            #T: abbreviation of month
+            mo = _("mo")
+            conf['timeTicks'] = {1: d, 7: w, 31: mo}[xunit]
         # types
         width = self.width
         height = self.height

--- a/anki/utils.py
+++ b/anki/utils.py
@@ -50,11 +50,17 @@ inTimeTable = {
 
 def shortTimeFmt(type):
     return {
+#T: year is an abbreviation for year. %s is a number of years
     "years": _("%sy"),
+#T: m is an abbreviation for month. %s is a number of months
     "months": _("%smo"),
+#T: d is an abbreviation for day. %s is a number of days
     "days": _("%sd"),
+#T: h is an abbreviation for hour. %s is a number of hours
     "hours": _("%sh"),
+#T: m is an abbreviation for minute. %s is a number of minutes
     "minutes": _("%sm"),
+#T: s is an abbreviation for second. %s is a number of seconds
     "seconds": _("%ss"),
     }[type]
 

--- a/aqt/browser.py
+++ b/aqt/browser.py
@@ -1060,6 +1060,8 @@ by clicking on one on the left."""))
 
                 # add templates
                 for c, tmpl in enumerate(nt['tmpls']):
+                    #T: name is a card type name. n it's order in the list of card type.
+                    #T: this is shown in browser's filter, when seeing the list of card type of a note type.
                     name = _("%(n)d: %(name)s") % dict(n=c+1, name=tmpl['name'])
                     subm.addItem(name, self._filterFunc(
                         "note", nt['name'], "card", str(c+1)))

--- a/designer/browser.ui
+++ b/designer/browser.ui
@@ -120,7 +120,7 @@
              <string>Preview</string>
             </property>
             <property name="shortcut">
-             <string>Ctrl+Shift+P</string>
+             <string notr="true">Ctrl+Shift+P</string>
             </property>
             <property name="checkable">
              <bool>true</bool>
@@ -327,7 +327,7 @@
     <string>&amp;Reschedule...</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Alt+R</string>
+    <string notr="true">Ctrl+Alt+R</string>
    </property>
   </action>
   <action name="actionSelectAll">
@@ -335,7 +335,7 @@
     <string>Select &amp;All</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Alt+A</string>
+    <string notr="true">Ctrl+Alt+A</string>
    </property>
   </action>
   <action name="actionUndo">
@@ -343,7 +343,7 @@
     <string>&amp;Undo</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Alt+Z</string>
+    <string notr="true">Ctrl+Alt+Z</string>
    </property>
   </action>
   <action name="actionInvertSelection">
@@ -351,7 +351,7 @@
     <string>&amp;Invert Selection</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Alt+S</string>
+    <string notr="true">Ctrl+Alt+S</string>
    </property>
   </action>
   <action name="actionFind">
@@ -359,7 +359,7 @@
     <string>&amp;Find</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+F</string>
+    <string notr="true">Ctrl+F</string>
    </property>
   </action>
   <action name="actionNote">
@@ -367,7 +367,7 @@
     <string>N&amp;ote</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Shift+N</string>
+    <string notr="true">Ctrl+Shift+N</string>
    </property>
   </action>
   <action name="actionNextCard">
@@ -375,7 +375,7 @@
     <string>&amp;Next Card</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+N</string>
+    <string notr="true">Ctrl+N</string>
    </property>
   </action>
   <action name="actionPreviousCard">
@@ -383,7 +383,7 @@
     <string>&amp;Previous Card</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+P</string>
+    <string notr="true">Ctrl+P</string>
    </property>
   </action>
   <action name="actionGuide">
@@ -391,7 +391,7 @@
     <string>&amp;Guide</string>
    </property>
    <property name="shortcut">
-    <string>F1</string>
+    <string notr="true">F1</string>
    </property>
   </action>
   <action name="actionChangeModel">
@@ -399,7 +399,7 @@
     <string>Change Note Type...</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Shift+M</string>
+    <string notr="true">Ctrl+Shift+M</string>
    </property>
   </action>
   <action name="actionSelectNotes">
@@ -412,7 +412,7 @@
     <string>Find and Re&amp;place...</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Alt+F</string>
+    <string notr="true">Ctrl+Alt+F</string>
    </property>
   </action>
   <action name="actionCram">
@@ -425,7 +425,7 @@
     <string>Fil&amp;ter</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Shift+F</string>
+    <string notr="true">Ctrl+Shift+F</string>
    </property>
   </action>
   <action name="actionCardList">
@@ -433,7 +433,7 @@
     <string>Card List</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Shift+L</string>
+    <string notr="true">Ctrl+Shift+L</string>
    </property>
   </action>
   <action name="actionFindDuplicates">
@@ -446,7 +446,7 @@
     <string>Reposition...</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Shift+S</string>
+    <string notr="true">Ctrl+Shift+S</string>
    </property>
   </action>
   <action name="actionFirstCard">
@@ -470,7 +470,7 @@
     <string>Close</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+W</string>
+    <string notr="true">Ctrl+W</string>
    </property>
   </action>
   <action name="action_Info">
@@ -478,7 +478,7 @@
     <string>&amp;Info...</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Shift+I</string>
+    <string notr="true">Ctrl+Shift+I</string>
    </property>
   </action>
   <action name="actionAdd_Tags">
@@ -486,7 +486,7 @@
     <string>Add Tags...</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Shift+A</string>
+    <string notr="true">Ctrl+Shift+A</string>
    </property>
   </action>
   <action name="actionRemove_Tags">
@@ -494,7 +494,7 @@
     <string>Remove Tags...</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Shift+D</string>
+    <string notr="true">Ctrl+Shift+D</string>
    </property>
   </action>
   <action name="actionToggle_Suspend">
@@ -502,7 +502,7 @@
     <string>Toggle Suspend</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+J</string>
+    <string notr="true">Ctrl+J</string>
    </property>
   </action>
   <action name="actionDelete">
@@ -510,7 +510,7 @@
     <string>Delete</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Del</string>
+    <string notr="true">Ctrl+Del</string>
    </property>
   </action>
   <action name="actionAdd">
@@ -518,7 +518,7 @@
     <string>Add Notes...</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+E</string>
+    <string notr="true">Ctrl+E</string>
    </property>
   </action>
   <action name="actionChange_Deck">
@@ -526,7 +526,7 @@
     <string>Change Deck...</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+D</string>
+    <string notr="true">Ctrl+D</string>
    </property>
   </action>
   <action name="actionRed_Flag">
@@ -537,7 +537,7 @@
     <string>Red Flag</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+1</string>
+    <string notr="true">Ctrl+1</string>
    </property>
   </action>
   <action name="actionOrange_Flag">
@@ -548,7 +548,7 @@
     <string>Orange Flag</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+2</string>
+    <string notr="true">Ctrl+2</string>
    </property>
   </action>
   <action name="actionGreen_Flag">
@@ -559,7 +559,7 @@
     <string>Green Flag</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+3</string>
+    <string notr="true">Ctrl+3</string>
    </property>
   </action>
   <action name="actionBlue_Flag">
@@ -570,7 +570,7 @@
     <string>Blue Flag</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+4</string>
+    <string notr="true">Ctrl+4</string>
    </property>
   </action>
   <action name="actionSidebar">
@@ -578,7 +578,7 @@
     <string>Sidebar</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Shift+R</string>
+    <string notr="true">Ctrl+Shift+R</string>
    </property>
   </action>
   <action name="actionClear_Unused_Tags">
@@ -596,7 +596,7 @@
     <string>Toggle Mark</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+K</string>
+    <string notr="true">Ctrl+K</string>
    </property>
   </action>
  </widget>

--- a/designer/customstudy.ui
+++ b/designer/customstudy.ui
@@ -69,7 +69,7 @@
       <item>
        <widget class="QLabel" name="title">
         <property name="text">
-         <string>...</string>
+         <string notr="true">...</string>
         </property>
        </widget>
       </item>
@@ -78,7 +78,7 @@
         <item>
          <widget class="QLabel" name="preSpin">
           <property name="text">
-           <string>...</string>
+           <string notr="true">...</string>
           </property>
          </widget>
         </item>
@@ -88,7 +88,7 @@
         <item>
          <widget class="QLabel" name="postSpin">
           <property name="text">
-           <string>...</string>
+           <string notr="true">...</string>
           </property>
          </widget>
         </item>

--- a/designer/main.ui
+++ b/designer/main.ui
@@ -101,7 +101,7 @@
     <string>E&amp;xit</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Q</string>
+    <string notr="true">Ctrl+Q</string>
    </property>
   </action>
   <action name="actionPreferences">
@@ -112,7 +112,7 @@
     <string>Configure interface language and options</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+P</string>
+    <string notr="true">Ctrl+P</string>
    </property>
    <property name="menuRole">
     <enum>QAction::PreferencesRole</enum>
@@ -134,7 +134,7 @@
     <string>&amp;Undo</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Z</string>
+    <string notr="true">Ctrl+Z</string>
    </property>
   </action>
   <action name="actionCheckMediaDatabase">
@@ -173,7 +173,7 @@
     <string>&amp;Guide...</string>
    </property>
    <property name="shortcut">
-    <string>F1</string>
+    <string notr="true">F1</string>
    </property>
   </action>
   <action name="actionSwitchProfile">
@@ -181,7 +181,7 @@
     <string>&amp;Switch Profile</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Shift+P</string>
+    <string notr="true">Ctrl+Shift+P</string>
    </property>
   </action>
   <action name="actionExport">
@@ -189,7 +189,7 @@
     <string>&amp;Export...</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+E</string>
+    <string notr="true">Ctrl+E</string>
    </property>
   </action>
   <action name="actionImport">
@@ -197,7 +197,7 @@
     <string>&amp;Import...</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Shift+I</string>
+    <string notr="true">Ctrl+Shift+I</string>
    </property>
   </action>
   <action name="actionStudyDeck">
@@ -205,7 +205,7 @@
     <string>Study Deck...</string>
    </property>
    <property name="shortcut">
-    <string>/</string>
+    <string notr="true">/</string>
    </property>
   </action>
   <action name="actionEmptyCards">
@@ -218,7 +218,7 @@
     <string>Create Filtered Deck...</string>
    </property>
    <property name="shortcut">
-    <string>F</string>
+    <string notr="true">F</string>
    </property>
   </action>
   <action name="actionNoteTypes">
@@ -226,7 +226,7 @@
     <string>Manage Note Types</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Shift+N</string>
+    <string notr="true">Ctrl+Shift+N</string>
    </property>
   </action>
   <action name="actionAdd_ons">
@@ -234,7 +234,7 @@
     <string>Add-ons</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Shift+A</string>
+    <string notr="true">Ctrl+Shift+A</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
There is currently a problem with crowdin. It asks to translate
shortcut. I assume that actually, shortcuts are intended to remain the
same independtly of the language, and thus that they should not appear
here.

I kind of assume that crowdin gets the strings to which _ or ngettext
are applied. So I wanted to ensure that none of those methods are
applied to shortcut.

The python file containing those shortcut are generated from .ui
files, used by QTCreator. I thus changed those files to indicates that
shortcuts should not be translated.

I assumed that shortcuts are strings containing either only "F(digit)",
a single letter, "Alt+" or "Ctrl+". I may have missed other shortcuts if they
exists.


I should note that it does not solve all crowdin related problem. For example, the first missing translation which I saw was "%(a)0.1fs (%(b)s)". I'm not really sure how it can be localized. Especially since crowdin does not gives context directly, and I should open the file myself and look for the line to understand where this occurs. And read format string specification to get what it means in practice.