### PR TITLE
Ensuring value of sortBackwards is a Boolean

### DIFF
--- a/aqt/browser.py
+++ b/aqt/browser.py
@@ -701,6 +701,7 @@ class Browser(QMainWindow):
         hh.sectionMoved.connect(self.onColumnMoved)
 
     def onSortChanged(self, idx, ord):
+        ord = bool(ord)
         self.editor.saveNow(lambda: self._onSortChanged(idx, ord))
 
     def _onSortChanged(self, idx, ord):


### PR DESCRIPTION
As far as Python is concerned, this commit does not change anything at
all. The purpose of this commit is to avoid a rare bug in
AnkiDroid. https://github.com/ankidroid/Anki-Android/issues/5523

Indeed, because of
hh.sortIndicatorChanged.connect(self.onSortChanged), onSortChanged may
be called with the values 0 or 1 instead of True or False. Which means
than the method getBoolean in Ankidroid may throw an exception,
stating that the value is an integer and not a Boolean.