### PR TITLE
Add "customize" label

### DIFF
--- a/aqt/editor.py
+++ b/aqt/editor.py
@@ -95,7 +95,7 @@ class Editor:
         righttopbtns.append(self._addButton('more', 'more'))
         righttopbtns = runFilter("setupEditorButtons", righttopbtns, self)
         topbuts = """
-            <div id="topbutsleft" style="float:left;">
+            <div id="topbutsleft" style="float:left;">%(customize)s
                 <button title='%(fldsTitle)s' onclick="pycmd('fields')">%(flds)s...</button>
                 <button title='%(cardsTitle)s' onclick="pycmd('cards')">%(cards)s...</button>
             </div>
@@ -104,6 +104,7 @@ class Editor:
             </div>
         """ % dict(flds=_("Fields"), cards=_("Cards"), rightbts="".join(righttopbtns),
                    fldsTitle=_("Customize Fields"),
+                   customize=_("Customize"),
                    cardsTitle=shortcut(_("Customize Card Templates (Ctrl+L)")))
         bgcol = self.mw.app.palette().window().color().name()
         # then load page

--- a/designer/addcards.ui
+++ b/designer/addcards.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>453</width>
+    <width>470</width>
     <height>366</height>
    </rect>
   </property>


### PR DESCRIPTION
Hello,

Both "Fields" and "Cards" buttons were displayed without any informative text. This makes it harder to understand what the buttons actually do.
As the current window is about editing cards, seeing a button "Cards" was not very clear.

I had to slightly increase the size of the window so everything fits.

Result:
![Screenshot from 2019-10-28 07-35-26](https://user-images.githubusercontent.com/564822/67656961-93e05600-f955-11e9-942f-d686b1ff0492.png)

I am not 100% convinced this is the best way to do so but I tried to clarify the interface with the minimum changes.
Would you be ok to discuss bigger changes in the interface, like moving these to specific menus or inside the advanced menu?