### PR TITLE
New model can be edited without full sync

### DIFF
--- a/anki/exporting.py
+++ b/anki/exporting.py
@@ -196,6 +196,9 @@ class AnkiExporter(Exporter):
         self.dst.models.models = {}
         for m in self.src.models.all():
             if int(m['id']) in mids:
+                m = m.copy()
+                if "ls" in m:
+                    del m["ls"]
                 self.dst.models.update(m)
         # decks
         if not self.did:

--- a/anki/importing/anki2.py
+++ b/anki/importing/anki2.py
@@ -220,6 +220,7 @@ class Anki2Importer(Importer):
                 model = srcModel.copy()
                 model['id'] = mid
                 model['usn'] = self.col.usn()
+                model['ls'] = self.col.ls
                 self.dst.models.update(model)
                 break
             # there's an existing model; do the schemas match?


### PR DESCRIPTION
This is of course related to #345. 

When a model is created (standard model or cloning) I set it
a value called "ls". This value is equal to col.ls. As long as both
value as equal, it means no sync did occur, and so it can be changed
for free.

Before upload, this value is removed. Indeed, it becomes useless. It clearly ensures that no change are required to ankiweb/ankidroid/ios/older Anki... Furthermore, even if for some reason, a dictionary with some value for "ls" was found in any of those programs, it would create absolutely no trouble since it's a JSON dictionnary and that they don't have to write a value themselves. 

Even if for some reason (an add-on, maybe) ["ls"] was not deleted during a sync, it would still create no trouble, since _modSchemaIfRequired would still realized that a sync did occur and it's currently not the good value for "ls".