### PR TITLE
Conflict Resolution with "--platformtheme"

### DIFF
--- a/aqt/__init__.py
+++ b/aqt/__init__.py
@@ -239,7 +239,8 @@ def parseArgs(argv):
     parser = argparse.ArgumentParser(description="Anki " + appVersion)
     parser.usage = "%(prog)s [OPTIONS] [file to import]"
     parser.add_argument("-b", "--base", help="path to base folder", default="")
-    parser.add_argument("-p", "--profile", help="profile name to load", default="")
+    parser.add_option("-P", "--profile", help="profile name to load", default="")
+    parser.add_option("-p", "--platformtheme", help="non-standard design theme (can only work on KDE)")
     parser.add_argument("-l", "--lang", help="interface language (en, de, etc)")
     return parser.parse_known_args(argv[1:])
 

--- a/aqt/__init__.py
+++ b/aqt/__init__.py
@@ -239,8 +239,8 @@ def parseArgs(argv):
     parser = argparse.ArgumentParser(description="Anki " + appVersion)
     parser.usage = "%(prog)s [OPTIONS] [file to import]"
     parser.add_argument("-b", "--base", help="path to base folder", default="")
-    parser.add_option("-P", "--profile", help="profile name to load", default="")
-    parser.add_option("-p", "--platformtheme", help="non-standard design theme (can only work on KDE)")
+    parser.add_argument("-P", "--profile", help="profile name to load", default="")
+    parser.add_argument("-p", "--platformtheme", help="non-standard design theme (can only work on KDE)")
     parser.add_argument("-l", "--lang", help="interface language (en, de, etc)")
     return parser.parse_known_args(argv[1:])
 


### PR DESCRIPTION
If you use KDE (or perhaps you just chose the dark theme of Qt design) and you have a dark theme selected, then the interface of Anki will not be displayed correctly. The text in the window will not be readable. Therefore, I use qt5ct for this problem. It allows you to choose a different theme. And for this you need to run the application with the argument "--platformtheme", but if you use it, anki will not start, because it will not understand this argument (although it doesn’t need to do this), or if you use it with one "-", it will see " -p" and it means that the profile is not correct.
Because I just added "--platformtheme" to the arguments parser. This solves it.

P.S 
I ran into this problem on Debian 10.
