### PR TITLE
Correct find flag

### DIFF
--- a/anki/find.py
+++ b/anki/find.py
@@ -275,7 +275,7 @@ select distinct(n.id) from cards c, notes n where c.nid=n.id and """+preds
 
     def _findFlag(self, args):
         (val, args) = args
-        if not val or val not in "01234":
+        if not val or len(val)!=1 or val not in "01234":
             return
         val = int(val)
         mask = 2**3 - 1

--- a/tests/test_find.py
+++ b/tests/test_find.py
@@ -224,6 +224,11 @@ def test_findCards():
                     id)
     assert len(deck.findCards("added:1")) == deck.cardCount() - 1
     assert len(deck.findCards("added:2")) == deck.cardCount()
+    # flag
+    with assert_raises(Exception):
+        deck.findCards("flag:01")
+    with assert_raises(Exception):
+        deck.findCards("flag:12")
 
 def test_findReplace():
     deck = getEmptyCol()


### PR DESCRIPTION
There is a little bug in anki, in which if you search for "flag:12" you don't see a message stating that the search is incorrect. This is because "12" is in "01234". So I also checked that the length of the flag is 1.

This time, I directly added the related test. I should note that there are no tests related to flag otherwise in the tests files.