### PR TITLE
Ignore sticky field only if they didnt changed

### DIFF
--- a/aqt/addcards.py
+++ b/aqt/addcards.py
@@ -186,9 +186,7 @@ question on all cards."""), help="AddItems")
 
     def _addCards(self):
         self.editor.saveAddModeVars()
-        note = self.editor.note
-        note = self.addNote(note)
-        if not note:
+        if not self.addNote(self.editor.note):
             return
         tooltip(_("Added"), period=500)
         # stop anything playing
@@ -222,7 +220,7 @@ question on all cards."""), help="AddItems")
 
     def ifCanClose(self, onOk):
         def afterSave():
-            ok = (self.editor.fieldsAreBlank() or
+            ok = (self.editor.fieldsAreBlank(self.previousNote) or
                     askUser(_("Close and lose current input?"), defaultno=True))
             if ok:
                 onOk()

--- a/aqt/addcards.py
+++ b/aqt/addcards.py
@@ -28,6 +28,7 @@ class AddCards(QDialog):
         self.setupButtons()
         self.onReset()
         self.history = []
+        self.previousNote = None
         restoreGeom(self, "add")
         addHook('reset', self.onReset)
         addHook('currentModelChanged', self.onModelChange)
@@ -83,6 +84,7 @@ class AddCards(QDialog):
     def onModelChange(self):
         oldNote = self.editor.note
         note = self.mw.col.newNote()
+        self.previousNote = None
         if oldNote:
             oldFields = list(oldNote.keys())
             newFields = list(note.keys())
@@ -176,6 +178,7 @@ question on all cards."""), help="AddItems")
             return
         self.addHistory(note)
         self.mw.requireReset()
+        self.previousNote = note
         return note
 
     def addCards(self):

--- a/aqt/editor.py
+++ b/aqt/editor.py
@@ -371,12 +371,15 @@ class Editor:
                               contents))
         browser.onSearchActivated()
 
-    def fieldsAreBlank(self):
+    def fieldsAreBlank(self, previousNote=None):
         if not self.note:
             return True
         m = self.note.model()
         for c, f in enumerate(self.note.fields):
-            if f and not m['flds'][c]['sticky']:
+            notChangedvalues = {"", "<br>"}
+            if previousNote and m['flds'][c]['sticky']:
+                notChangedvalues.add(previousNote.fields[c])
+            if f not in notChangedvalues:
                 return False
         return True
 


### PR DESCRIPTION
I do appreciate that anki asks "Close and lose current input?" when there are some content in a field. However, I find it disturbing that the question is not asked for sticky fields; in particular when the value of the field did change. 
I don't know whether it'd be considered as a bug or not. So I don't event know whether you want to correct it

So I created an add-on, and now thought I might create a similar PR, which compares a note with the previously added note. And it ignores sticky field only if their value didn't change. So if I did enter a new value in a sticky field, I'm warned.

To test it, simply create a note with a sticky field, change the content of the sticky field, try to close the window. You'll see you're warned.