### PR TITLE
Fix minor race condition in rendering of the preview window

### DIFF
--- a/aqt/browser.py
+++ b/aqt/browser.py
@@ -1375,7 +1375,7 @@ where id in %s""" % ids2str(sf))
         elapMS = int((time.time() - self._lastPreviewRender)*1000)
         if elapMS < 500:
             self._previewTimer = self.mw.progress.timer(
-                500-elapMS, lambda: self._renderScheduledPreview(), False)
+                500-elapMS, self._renderScheduledPreview, False)
         else:
             self._renderScheduledPreview()
 


### PR DESCRIPTION
This PR fixes a minor race condition in rendering of the preview window.

### Reproducing the problem
- Open the Preview window in Card Browser
- Press the "Preview Next" button twice in quick succession (less than 500ms between keypresses)

**Expected result:**
The first keypress shows the answer for the first card.
The next keypress changes to the next card, where the question is shown.

**Actual result:**
The first keypress shows the answer for the first card.
The next keypress shows the answer for the second card.

This can be an issue, for instance if you want to use the preview window to quickly go through some cards without all the machinery of creating a custom filtered deck.

### Explanation of the race condition
This race condition is caused by the throttling of repeated calls to `_renderPreview(cardChanged)` in `browser.py`.

If `_renderPreview(True)` is throttled, and `_renderPreview(False)` is called before the end of the timer, the final result will be that `cardChanged==False`, and `self._previewState` is never set back to `"question"`.

When rapidly pressing the "Preview Next" button, the following will happen:

1. The first keypress causes `self._onPreviewNext() -> self.renderPreview(False)`
2. The second keypress triggers `self._onRowChanged() -> self.renderPreview(True)`. Since this happens shortly after the previous `self.renderPreview()`, it is throttled.
3. The second keypress also triggers `self.onLoadNote() -> ... -> self.renderPreview(False)`. This overrides the previously throttled `self.renderPreview(True)`, so eventually the preview is rendered with `cardChanged==False`.

### Suggested fix

This PR keeps track of whether `self._renderPreview()` was ever called with `cardChanged==True` after the last successful render, and if so, the next render happens with `cardChanged==True`.

This is certainly not the cleanest way to achieve the intended behaviour (ideally, we should get rid of the whole cardChanged argument and the repeated calls to self.renderPreview()), but this fix is a way to keep the changes to a minimum, and also keep the method signature of `self._renderPreview()` constant in case it is used by any addons.

The PR does change the signature of `self._renderScheduledPreview()`. I would expect it to be relatively unlikely that any addons depend directly on `self._renderScheduledPreview()`, but feel free to let me know if you think it is important to keep this signature constant as well.

I must also admit that I have not run the test suite against this PR, since it would be a hassle in my current Windows environment. However, as far as I can see, the aqt-part of the codebase is not covered by the test suite anyway, so I would not expect this to break any tests.

I must also say that, in my opinion, the 500ms throttle limit is too long. It makes the preview window feel sluggish. Have you considered something like 200ms?