### PR TITLE
Fire cardAnswered event after call to _answerCard

### DIFF
--- a/aqt/reviewer.py
+++ b/aqt/reviewer.py
@@ -238,6 +238,7 @@ The front of this card is empty. Please run Tools>Empty Cards.""")
         self._answeredIds.append(self.card.id)
         self.mw.autosave()
         self.nextCard()
+        runHook('cardAnswered')
 
     # Handlers
     ############################################################
@@ -608,7 +609,7 @@ time = %(time)d;
             [_("Replay Own Voice"), "V", self.onReplayRecorded],
         ]
         return opts
-    
+
     def showContextMenu(self):
         opts = self._contextMenu()
         m = QMenu(self.mw)


### PR DESCRIPTION
This is a proposal to add a `cardAnswered` hook, triggered at the end of the `Reviewer._cardAnswer` method.
From the perspective of the interface, this event is triggered every time a card is answered in the reviewer.

The purpose of this is to permit the [autolearn add-on](https://github.com/Afoucaul/anki-autolearn) to run on the official version.
This add-on, which I wrote, consists in having the reviewer window pop up every few minutes so as to force the study, and then disappear once it has been answered - hence the new hook.

Please do let me know if you have any feedback regarding this PR, and regarding the autolearn add-on as well.