### PR TITLE
list of decks contains default iff deck chooser contains default

### DIFF
--- a/anki/decks.py
+++ b/anki/decks.py
@@ -206,16 +206,19 @@ class DeckManager:
             self.select(int(list(self.decks.keys())[0]))
         self.save()
 
-    def allNames(self, dyn=True):
+    def allNames(self, dyn=True, forceDefault=True):
         "An unsorted list of all deck names."
         if dyn:
-            return [x['name'] for x in list(self.decks.values())]
+            return [x['name'] for x in self.all(forceDefault=forceDefault)]
         else:
-            return [x['name'] for x in list(self.decks.values()) if not x['dyn']]
+            return [x['name'] for x in self.all(forceDefault=forceDefault) if not x['dyn']]
 
-    def all(self):
+    def all(self, forceDefault=True):
         "A list of all decks."
-        return list(self.decks.values())
+        decks = list(self.decks.values())
+        if not forceDefault and not self.col.db.scalar("select 1 from cards where did = 1 limit 1") and len(decks)>1:
+            decks = [deck for deck in decks if deck['id'] != 1]
+        return decks
 
     def allIds(self):
         return list(self.decks.keys())

--- a/aqt/studydeck.py
+++ b/aqt/studydeck.py
@@ -38,7 +38,7 @@ class StudyDeck(QDialog):
         if title:
             self.setWindowTitle(title)
         if not names:
-            names = sorted(self.mw.col.decks.allNames(dyn=dyn))
+            names = sorted(self.mw.col.decks.allNames(dyn=dyn, forceDefault=False))
             self.nameFunc = None
             self.origNames = names
         else:


### PR DESCRIPTION
I don't exactly know whether it'd be considered as a bug or not. In a collection with a deck A with cards in it, the users does not see "default" in the deck browser. But they may see it in the study deck window. Which is useless since there is nothing to study anyway. So I ensured both windows where consistent.

I must remark that it also means that default can't be chosen when adding/moving a card. If you prefer Default to be still accessible in those cases, I can easily edit the code to allow it.