### PR TITLE
Allow to remove useless column from browser

### DIFF
--- a/aqt/browser.py
+++ b/aqt/browser.py
@@ -111,7 +111,7 @@ class DataModel(QAbstractTableModel):
                     break
             # handle case where extension has set an invalid column type
             if not txt:
-                txt = self.browser.columns[0][1]
+                txt = _(type)
             return txt
         else:
             return
@@ -548,7 +548,14 @@ class Browser(QMainWindow):
             ('noteTags', _("Tags")),
             ('note', _("Note")),
         ]
-        self.columns.sort(key=itemgetter(1))
+        types = {type for type, name in self.columns}
+        for column in self.col.conf.get("activeCols", []):
+            if column not in types:
+                self.columns.append((column, _(column)))
+                types.add(column)
+        self.columns.sort(key=itemgetter(1)) # allow to sort by
+                                             # alphabetical order in
+                                             # the local language
 
     # Searching
     ######################################################################
@@ -769,6 +776,7 @@ by clicking on one on the left."""))
                 self.model.endReset()
                 return showInfo(_("You must have at least one column."))
             self.model.activeCols.remove(type)
+            self.setupColumns() #in case we removed a column which should disappear
             adding=False
         else:
             self.model.activeCols.append(type)


### PR DESCRIPTION
Currently, if for some reason, the browser have an active columns
which does not exists, instead of showing any information to the user
related to the column, it shows the name of the alphabetically first
column. This makes little sens. And worse, this column can't be
removed. Indeed, intuitively the user may want to click on the name
shown in the column to remove it. Instead it'll add the real first
column (or remove it if it really was here. In which case it only
removes the column with actual information.)

I thus do believe that it is slighly better to allow the user to
remove any useless columns (and not to add them back. At worst, the
add-on creating those columns will deal with them)
To do so, I add to show the "type" of the columns, since I don't have
access to their name.

Another solution which would makes sens too would simply be to hide
those columns from the users. Note that this would create potentially
a problem because in this case they may have 0 columns shown if all
active columns are columns anki does not know

To test this, you can easily open the debugger, and add faulty names to "activeCols".
E.g. 
`
from aqt import mw
mw.col.conf["activeCols"]+= ["faulty name", "other faulty name"]
`
open the browser and check that you can remove columns and not add them back (or you could do it the more natural way, using add-on adding columns and then disabling the add-on and restarting anki)