### PR TITLE
Use _deckNewLimitSingle in _groupChildrenMain

### DIFF
--- a/anki/sched.py
+++ b/anki/sched.py
@@ -293,7 +293,7 @@ order by due""" % self._deckLimit(),
             deck = self.col.decks.get(did)
             if not conf['dyn']:
                 rev = max(0, min(rev, conf['rev']['perDay']-deck['revToday'][1]))
-                new = max(0, min(new, conf['new']['perDay']-deck['newToday'][1]))
+                new = max(0, min(new, self._deckNewLimitSingle(deck)))
             tree.append((head, did, rev, lrn, new, children))
         return tuple(tree)
 

--- a/anki/schedv2.py
+++ b/anki/schedv2.py
@@ -294,7 +294,7 @@ order by due""" % self._deckLimit(),
             conf = self.col.decks.confForDid(did)
             deck = self.col.decks.get(did)
             if not conf['dyn']:
-                new = max(0, min(new, conf['new']['perDay']-deck['newToday'][1]))
+                new = max(0, min(new, self._deckNewLimitSingle(deck)))
             tree.append((head, did, rev, lrn, new, children))
         return tuple(tree)
 


### PR DESCRIPTION
I wrote an add-on that reduces new cards per day according to total cards studied and scheduled learn and review cards, by wrapping _deckNewLimitSingle. This worked as expected except that the decks list showed inconsistent new card counts. I fixed this by monkey patching _groupChildrenMain to use self._deckNewLimitSingle instead of getting new perDay from the deck config. This leaves just one place the config is read: _deckNewLimitSingle. Everywhere else (that i could find), the deck new card per day limit is obtained from _deckNewLimitSingle. With this change, the deck list shows consistent new card counts.

I was unable to run the tests (make check) because I got lost in a series of undocumented dependencies and gave up on mypy PyQt5 stubs not found. I don't know python. This is likely my fault for not doing things the "python" way. None the less, anki runs fine as I use it and I am pleased with how my add-on works.

I offer this pull request, in case you might be interested to incorporate the change to _groupChildrenMain. If you do, I won't need to monkey patch it in my add-on, which would be nice.

Feel free to ignore this if it is not suitable to you. My add-on works fine with the monkey patching. I won't be offended.

Thank you for making anki available. It is a wonderful tool for learning.