### PR TITLE
Add types for models, templates and field dicts

### DIFF
--- a/anki/collection.py
+++ b/anki/collection.py
@@ -33,6 +33,7 @@ from anki.sched import Scheduler as V1Scheduler
 from anki.schedv2 import Scheduler as V2Scheduler
 from anki.sound import stripSounds
 from anki.tags import TagManager
+from anki.types import Model, Template
 from anki.utils import (devMode, fieldChecksum, ids2str, intTime, joinFields,
                         maxID, splitFields, stripHTMLMedia)
 
@@ -354,7 +355,7 @@ crt=?, mod=?, scm=?, dty=?, usn=?, ls=?, conf=?""",
         avail = self.models.availOrds(model, joinFields(note.fields))
         return self._tmplsFromOrds(model, avail)
 
-    def _tmplsFromOrds(self, model: Dict[str, Any], avail: List[int]) -> List:
+    def _tmplsFromOrds(self, model: Model, avail: List[int]) -> List:
         ok = []
         if model['type'] == MODEL_STD:
             for t in model['tmpls']:
@@ -456,7 +457,7 @@ insert into cards values (?,?,?,?,?,?,0,0,?,0,0,0,0,0,0,0,0,"")""",
             cards.append(self._newCard(note, template, 1, flush=False, did=did))
         return cards
 
-    def _newCard(self, note: Note, template: Dict[str, Any], due: int, flush: bool = True, did: None = None) -> anki.cards.Card:
+    def _newCard(self, note: Note, template: Template, due: int, flush: bool = True, did: None = None) -> anki.cards.Card:
         "Create a new card."
         card = anki.cards.Card(self)
         card.nid = note.id
@@ -465,7 +466,7 @@ insert into cards values (?,?,?,?,?,?,0,0,?,0,0,0,0,0,0,0,0,"")""",
         # Use template did (deck override) if valid, otherwise did in argument, otherwise model did
         if not card.did:
             if template['did'] and str(template['did']) in self.decks.decks:
-                card.did = template['did']
+                card.did = int(template['did'])
             elif did:
                 card.did = did
             else:

--- a/anki/latex.py
+++ b/anki/latex.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Optional, Union
 
 from anki.hooks import addHook
 from anki.lang import _
+from anki.types import Model
 from anki.utils import call, checksum, isMac, namedtmp, stripHTML, tmpdir
 
 pngCommands = [
@@ -42,7 +43,8 @@ def stripLatex(text) -> Any:
         text = text.replace(match.group(), "")
     return text
 
-def mungeQA(html: str, type: Optional[str], fields: Optional[Dict[str, str]], model: Dict[str, Any], data: Optional[List[Union[int, str]]], col) -> Any:
+def mungeQA(html: str, type: Optional[str], fields: Optional[Dict[str, str]],
+            model: Model, data: Optional[List[Union[int, str]]], col) -> Any:
     "Convert TEXT with embedded latex tags to image links."
     for match in regexps['standard'].finditer(html):
         html = html.replace(match.group(), _imgLink(col, match.group(1), model))
@@ -55,7 +57,7 @@ def mungeQA(html: str, type: Optional[str], fields: Optional[Dict[str, str]], mo
             "\\begin{displaymath}" + match.group(1) + "\\end{displaymath}", model))
     return html
 
-def _imgLink(col, latex: str, model: Dict[str, Any]) -> Any:
+def _imgLink(col, latex: str, model: Model) -> str:
     "Return an img link for LATEX, creating if necesssary."
     txt = _latexFromHtml(col, latex)
 
@@ -80,13 +82,13 @@ def _imgLink(col, latex: str, model: Dict[str, Any]) -> Any:
     else:
         return link
 
-def _latexFromHtml(col, latex: str) -> Any:
+def _latexFromHtml(col, latex: str) -> str:
     "Convert entities and fix newlines."
     latex = re.sub("<br( /)?>|<div>", "\n", latex)
     latex = stripHTML(latex)
     return latex
 
-def _buildImg(col, latex: str, fname: str, model: Dict[str, Any]) -> Any:
+def _buildImg(col, latex: str, fname: str, model: Model) -> Optional[str]:
     # add header/footer
     latex = (model["latexPre"] + "\n" +
              latex + "\n" +
@@ -129,7 +131,7 @@ package in the LaTeX header instead.""") % bad
                 return _errMsg(latexCmd[0], texpath)
         # add to media
         shutil.copyfile(png, os.path.join(mdir, fname))
-        return
+        return None
     finally:
         os.chdir(oldcwd)
         log.close()

--- a/anki/stdmodels.py
+++ b/anki/stdmodels.py
@@ -1,17 +1,18 @@
 # -*- coding: utf-8 -*-
 # Copyright: Ankitects Pty Ltd and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
-from typing import Any, Dict
+from typing import Any, Callable, List, Tuple
 
 from anki.consts import MODEL_CLOZE
 from anki.lang import _
+from anki.types import Model
 
-models = []
+models: List[Tuple[Callable[[], str], Callable[[Any], Model]]] = []
 
 # Basic
 ##########################################################################
 
-def _newBasicModel(col, name=None) -> Dict[str, Any]:
+def _newBasicModel(col, name=None) -> Model:
     mm = col.models
     m = mm.new(name or _("Basic"))
     fm = mm.newField(_("Front"))
@@ -24,7 +25,7 @@ def _newBasicModel(col, name=None) -> Dict[str, Any]:
     mm.addTemplate(m, t)
     return m
 
-def addBasicModel(col) -> Dict[str, Any]:
+def addBasicModel(col) -> Model:
     m = _newBasicModel(col)
     col.models.add(m)
     return m
@@ -34,7 +35,7 @@ models.append((lambda: _("Basic"), addBasicModel))
 # Basic w/ typing
 ##########################################################################
 
-def addBasicTypingModel(col) -> Dict[str, Any]:
+def addBasicTypingModel(col) -> Model:
     mm = col.models
     m = _newBasicModel(col, _("Basic (type in the answer)"))
     t = m['tmpls'][0]
@@ -48,7 +49,7 @@ models.append((lambda: _("Basic (type in the answer)"), addBasicTypingModel))
 # Forward & Reverse
 ##########################################################################
 
-def _newForwardReverse(col, name=None) -> Dict[str, Any]:
+def _newForwardReverse(col, name=None) -> Model:
     mm = col.models
     m = _newBasicModel(col, name or _("Basic (and reversed card)"))
     t = mm.newTemplate(_("Card 2"))
@@ -57,7 +58,7 @@ def _newForwardReverse(col, name=None) -> Dict[str, Any]:
     mm.addTemplate(m, t)
     return m
 
-def addForwardReverse(col) -> Dict[str, Any]:
+def addForwardReverse(col) -> Model:
     m = _newForwardReverse(col)
     col.models.add(m)
     return m
@@ -67,7 +68,7 @@ models.append((lambda: _("Basic (and reversed card)"), addForwardReverse))
 # Forward & Optional Reverse
 ##########################################################################
 
-def addForwardOptionalReverse(col) -> Dict[str, Any]:
+def addForwardOptionalReverse(col) -> Model:
     mm = col.models
     m = _newForwardReverse(col, _("Basic (optional reversed card)"))
     av = _("Add Reverse")
@@ -84,7 +85,7 @@ models.append((lambda: _("Basic (optional reversed card)"),
 # Cloze
 ##########################################################################
 
-def addClozeModel(col) -> Dict[str, Any]:
+def addClozeModel(col) -> Model:
     mm = col.models
     m = mm.new(_("Cloze"))
     m['type'] = MODEL_CLOZE

--- a/anki/types.py
+++ b/anki/types.py
@@ -1,0 +1,12 @@
+from typing import Any, Dict, Union
+
+# Model attributes are stored in a dict keyed by strings. This type alias
+# provides more descriptive function signatures than just 'Dict[str, Any]'
+# for methods that operate on models.
+# TODO: Use https://www.python.org/dev/peps/pep-0589/ when available in
+# supported Python versions.
+Model = Dict[str, Any]
+
+Field = Dict[str, Any]
+
+Template = Dict[str, Union[str, int, None]]

--- a/anki/utils.py
+++ b/anki/utils.py
@@ -52,7 +52,7 @@ inTimeTable = {
     "seconds": lambda n: ngettext("in %s second", "in %s seconds", n),
     }
 
-def shortTimeFmt(type: str) -> Any:
+def shortTimeFmt(type: str) -> str:
     return {
 #T: year is an abbreviation for year. %s is a number of years
     "years": _("%sy"),
@@ -84,7 +84,7 @@ def fmtTimeSpan(time: Union[int, float], pad: int = 0, point: int = 0, short: bo
     timestr = "%%%(a)d.%(b)df" % {'a': pad, 'b': point}
     return locale.format_string(fmt % timestr, time)
 
-def optimalPeriod(time: Union[int, float], point: int, unit: int) -> Tuple[str, Any]:
+def optimalPeriod(time: Union[int, float], point: int, unit: int) -> Tuple[str, int]:
     if abs(time) < 60 or unit < 1:
         type = "seconds"
         point -= 1
@@ -152,7 +152,7 @@ def stripHTML(s: str) -> str:
     s = entsToTxt(s)
     return s
 
-def stripHTMLMedia(s: str) -> Any:
+def stripHTMLMedia(s: str) -> str:
     "Strip HTML but keep media filenames"
     s = reMedia.sub(" \\1 ", s)
     return stripHTML(s)
@@ -167,7 +167,7 @@ def minimizeHTML(s) -> str:
                '<u>\\1</u>', s)
     return s
 
-def htmlToTextLine(s) -> Any:
+def htmlToTextLine(s) -> str:
     s = s.replace("<br>", " ")
     s = s.replace("<br />", " ")
     s = s.replace("<div>", " ")


### PR DESCRIPTION
* Replaces occurrences of `Dict[str, Any]` with one of Template, Model, Field. Since those are currently aliases to `Dict[str, Any]`, this doesn't provide more checking (they can still be assigned to one another), but it should give more readable function headers.
* Replaced a few `Any`s with mode proper types.