### PR TITLE
Allow handing config editing back to Anki after calling add-on action

### DIFF
--- a/aqt/addons.py
+++ b/aqt/addons.py
@@ -6,7 +6,7 @@ import json
 import re
 import zipfile
 from collections import defaultdict
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, Optional
 from zipfile import ZipFile
 
 import jsonschema
@@ -358,7 +358,7 @@ and have been disabled: %(found)s") % dict(name=self.addonName(dir), found=addon
     # Add-on Config
     ######################################################################
 
-    _configButtonActions: Dict[str, Callable[[], None]] = {}
+    _configButtonActions: Dict[str, Callable[[], Optional[bool]]] = {}
     _configUpdatedActions: Dict[str, Callable[[Any], None]] = {}
 
     def addonConfigDefaults(self, dir):
@@ -640,8 +640,9 @@ class AddonsDialog(QDialog):
         # does add-on manage its own config?
         act = self.mgr.configAction(addon)
         if act:
-            act()
-            return
+            ret = act()
+            if ret is not False:
+                return
 
         conf = self.mgr.getConfig(addon)
         if conf is None:


### PR DESCRIPTION
Allows add-ons to partially manage their own configuration while still delegating the actual UI to Anki.

A use case for this would be add-ons caching config modifications themselves, deferring writing the changes until particular events call for it (i.e. in this case opening the config dialog). More generally speaking, this will allow add-ons to have more control over config editing without having to implement their own UI.

This does make a return value meaningful that used to be irrelevant, which is not ideal for API compatibility. However, performing a [search for add-ons using the setConfigAction API](https://github.com/search?p=1&q=addonManager.setConfigAction&type=Code), I wasn't able to find any that explicitly returned from their config action. Still, if this is a concern, I would be happy to use a string or a different return type instead to signal back to Anki.