### PR TITLE
Fix schedv2 _daysSinceCreation

### DIFF
--- a/anki/schedv2.py
+++ b/anki/schedv2.py
@@ -1249,10 +1249,19 @@ where id = ?
         return stamp
 
     def _daysSinceCreation(self) -> int:
-        startDate = datetime.datetime.fromtimestamp(self.col.crt)
-        startDate = startDate.replace(hour=self.col.conf.get("rollover", 4),
-                                      minute=0, second=0, microsecond=0)
-        return int((time.time() - time.mktime(startDate.timetuple())) // 86400)
+        rolloverTime = self.col.conf.get("rollover", 4)
+        if rolloverTime < 0:
+            rolloverTime = 24+rolloverTime
+        startTime = datetime.datetime.fromtimestamp(self.col.crt)
+        startDate = startTime.date()
+        if startTime.hour < rolloverTime:
+            startDate = startDate + datetime.timedelta(days=-1)
+        endTime = datetime.datetime.today()
+        endDate = endTime.date()
+        if endTime.hour < rolloverTime:
+            endDate = startDate + datetime.timedelta(days=-1)
+        delta = endDate - startDate
+        return delta.days
 
     # Deck finished state
     ##########################################################################


### PR DESCRIPTION
Effective rollover time and calculation of days since creation were
incorrect when localtime has daylight saving time and the interval from
creation to today spans an odd number of transitions between standard
and daylight saving time. The reason for this is that at the transition
between standard and daylight saving time, the day is not 86400 seconds.