### PR TITLE
Fix bug in _removeFormattingFromMathjax

### DIFF
--- a/anki/template/template.py
+++ b/anki/template/template.py
@@ -4,9 +4,7 @@ from typing import Any, Callable, Dict, Pattern
 from anki.hooks import runFilter
 from anki.utils import stripHTML, stripHTMLMedia
 
-# The (?si) flags make the regex match case-insensitively and make . match any
-# character including newlines.
-# See: https://docs.python.org/3/howto/regex.html#compilation-flags
+# Matches a {{c123::clozed-out text::hint}} Cloze deletion, case-insensitively.
 clozeReg = r"(?si)\{\{(c)%s::(.*?)(::(.*?))?\}\}"
 
 modifiers: Dict[str, Callable] = {}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -199,18 +199,12 @@ def test_cloze_mathjax():
     assert "class=cloze" in f.cards()[3].q()
     assert "class=cloze" in f.cards()[4].q()
 
-def test_cloze_mathjax_bug():
-    d = getEmptyCol()
-    d.models.setCurrent(d.models.byName("Cloze"))
-
     f = d.newNote()
     f['Text'] = r'\(a\) {{c1::b}} \[ {{c1::c}} \]'
     assert d.addNote(f)
     assert len(f.cards()) == 1
+    assert f.cards()[0].q().endswith('\(a\) <span class=cloze>[...]</span> \[ [...] \]')
 
-    # TODO: The following assertion should work, but currently fails due
-    # to a bug in _removeFormatingFromMathjax.
-    #   assert f.cards()[0].q() == '\(a\) <span class=cloze>[...]</span> \[ [...] \]'
 
 def test_chained_mods():
     d = getEmptyCol()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -199,6 +199,19 @@ def test_cloze_mathjax():
     assert "class=cloze" in f.cards()[3].q()
     assert "class=cloze" in f.cards()[4].q()
 
+def test_cloze_mathjax_bug():
+    d = getEmptyCol()
+    d.models.setCurrent(d.models.byName("Cloze"))
+
+    f = d.newNote()
+    f['Text'] = r'\(a\) {{c1::b}} \[ {{c1::c}} \]'
+    assert d.addNote(f)
+    assert len(f.cards()) == 1
+
+    # TODO: The following assertion should work, but currently fails due
+    # to a bug in _removeFormatingFromMathjax.
+    #   assert f.cards()[0].q() == '\(a\) <span class=cloze>[...]</span> \[ [...] \]'
+
 def test_chained_mods():
     d = getEmptyCol()
     d.models.setCurrent(d.models.byName("Cloze"))

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -11,6 +11,6 @@ def test_remove_formatting_from_mathjax():
     # formatting.
     assert t._removeFormattingFromMathjax(txt, 2) == txt
 
-    # TODO: r'\(a\) {{c1::b}} \[ {{c1::c}} \]', ord=1 should return
-    # r'\(a\) {{c1::b}} \[ {{C1::c}} \]', but actually fails to mark the cloze
-    # as not-to-be-formatted.
+    txt = r'\(a\) {{c1::b}} \[ {{c1::c}} \]'
+    assert t._removeFormattingFromMathjax(txt, 1) == (
+        r'\(a\) {{c1::b}} \[ {{C1::c}} \]')

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,0 +1,16 @@
+from anki.template import Template
+
+
+def test_remove_formatting_from_mathjax():
+    t = Template('')
+    assert t._removeFormattingFromMathjax(r'\(2^{{c3::2}}\)', 3) == r'\(2^{{C3::2}}\)'
+
+    txt = (r'{{c1::ok}} \(2^2\) {{c2::not ok}} \(2^{{c3::2}}\) \(x^3\) '
+           r'{{c4::blah}} {{c5::text with \(x^2\) jax}}')
+    # Cloze 2 is not in MathJax, so it should not get protected against
+    # formatting.
+    assert t._removeFormattingFromMathjax(txt, 2) == txt
+
+    # TODO: r'\(a\) {{c1::b}} \[ {{c1::c}} \]', ord=1 should return
+    # r'\(a\) {{c1::b}} \[ {{C1::c}} \]', but actually fails to mark the cloze
+    # as not-to-be-formatted.


### PR DESCRIPTION
Also adds some comments I wrote to help me understand what's going
on in the code.

I hope to fix this bug myself, but I think it might be beyond what
you can do with Python regexes and might require writing a proper
parser.

So, as step 1, I'm adding in a couple comments explaining that the
bug exists and how to reproduce it.

The bug is: if you put `\(a\) {{c1::b}} \[ {{c1::c}} \]`, the Cloze card will render incorrectly:
![image](https://user-images.githubusercontent.com/714892/71317009-8f7a7a00-247a-11ea-930a-4192bda98076.png)
