### PR TITLE
Use named tuple to represent QA data

### DIFF
--- a/anki/collection.py
+++ b/anki/collection.py
@@ -33,7 +33,7 @@ from anki.sched import Scheduler as V1Scheduler
 from anki.schedv2 import Scheduler as V2Scheduler
 from anki.sound import stripSounds
 from anki.tags import TagManager
-from anki.types import NoteType, Template
+from anki.types import NoteType, QAData, Template
 from anki.utils import (devMode, fieldChecksum, ids2str, intTime, joinFields,
                         maxID, splitFields, stripHTMLMedia)
 
@@ -578,7 +578,7 @@ where c.nid = n.id and c.id in %s group by nid""" % ids2str(cids)):
         return [self._renderQA(row)
                 for row in self._qaData(where)]
 
-    def _renderQA(self, data: Tuple[int,int,int,int,int,str,str,int], qfmt: None = None, afmt: None = None) -> Dict:
+    def _renderQA(self, data: QAData, qfmt: None = None, afmt: None = None) -> Dict:
         "Returns hash of id, question, answer."
         # data is [cid, nid, mid, did, ord, tags, flds, cardFlags]
         # unpack fields and create dict
@@ -627,6 +627,7 @@ where c.nid = n.id and c.id in %s group by nid""" % ids2str(cids)):
 
     def _qaData(self, where="") -> Any:
         "Return [cid, nid, mid, did, ord, tags, flds, cardFlags] db query"
+        # NOTE: order selected from database must match order of QAData fields.
         return self.db.execute("""
 select c.id, f.id, f.mid, c.did, c.ord, f.tags, f.flds, c.flags
 from cards c, notes f

--- a/anki/types.py
+++ b/anki/types.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Union
+from typing import Any, Dict, Tuple, Union
 
 # Model attributes are stored in a dict keyed by strings. This type alias
 # provides more descriptive function signatures than just 'Dict[str, Any]'
@@ -11,3 +11,23 @@ NoteType = Dict[str, Any]
 Field = Dict[str, Any]
 
 Template = Dict[str, Union[str, int, None]]
+
+QAData = Tuple[
+    # Card ID this QA comes from. Corresponds to 'cid' column.
+    int,
+    # Note ID this QA comes from. Corresponds to 'nid' column.
+    int,
+    # ID of the model (i.e., NoteType) for this QA's note. Corresponds to 'mid' column.
+    int,
+    # Deck ID. Corresponds to 'did' column.
+    int,
+    # Index of the card template (within the NoteType) this QA was built
+    # from. Corresponds to 'ord' column.
+    int,
+    # Tags, separated by space. Corresponds to 'tags' column.
+    str,
+    # Corresponds to 'flds' column. TODO: document.
+    str,
+    # Corresponds to 'cardFlags' column. TODO: document
+    int
+]


### PR DESCRIPTION
Putting QA data into a named tuple allows referring to the fields with e.g. `qa_data.did` instead of `qa_data[3]`, which is easier to read.