### PR TITLE
Correcting showing errors while importing

### DIFF
--- a/aqt/importing.py
+++ b/aqt/importing.py
@@ -199,7 +199,7 @@ you can enter it here. Use \\t to represent tab."""
             elif "invalidTempFolder" in err:
                 msg += self.mw.errorHandler.tempFolderMsg()
             else:
-                msg += str(traceback.format_exc(), "ascii", "replace")
+                msg += traceback.format_exc()
             showText(msg)
             return
         finally:


### PR DESCRIPTION
An add-on made some importing raise an exception. During the
exception, an other exception was raised, because of this line. It stated:

TypeError: decoding str is not supported

I'm not sure my correction is the good one, because I don't understand
why you want to apply `str` to a string. But if it's an incorrect
correction, at least, this could serve as a bug report

I tested it in the following way. Using the faulty version of the add-on, I tried to import again. The exception was correctly displayed this time.